### PR TITLE
Per tick rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Not well, but it's good enough to play some moderately complex stuff.
 | `pulseaudio` | PulseAudio support is offered through a Pure Go interface originally created by Johann Freymuth, called [jfreymuth/pulse](https://github.com/jfreymuth/pulse). While it seems to work pretty well, it does have some inconsistencies when compared to the FreeDesktop supported C interface. If you see an error about there being a "`missing port in address`" specifically when using a TCP connection string, make sure to append the default port specifier of `:4713` to the end of the `PULSE_SERVER` environment variable. |
 | `windows` `directsound` | DirectSound integration is not great code. It works well enough after recent code changes fixing event support, but it's still pretty ugly. |
 | `flac` | Flac encoding is still very beta. |
-| `player` | Tracker `speed` values which are very long (`1F` for example) will usually underflow the output buffers when played directly through a sound card device. This is caused by the playback system being row-based and not tick-based. Attempts to resolve this will be coming soon-ish. |
 
 ### Unknown bugs
 

--- a/gotracker.go
+++ b/gotracker.go
@@ -83,7 +83,9 @@ func main() {
 		row := premix.Userdata.(*render.RowRender)
 		switch deviceKind {
 		case device.KindSoundCard:
-			fmt.Printf("[%0.3d:%0.3d] %s\n", row.Order, row.Row, row.RowText.String())
+			if row.RowText != nil {
+				fmt.Printf("[%0.3d:%0.3d] %s\n", row.Order, row.Row, row.RowText.String())
+			}
 		case device.KindFile:
 			if progress == nil {
 				progress = progressBar.StartNew(playback.GetNumOrders())

--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -35,8 +35,9 @@ type Manager struct {
 	preMixRowTxn  intf.SongPositionState
 	postMixRowTxn intf.SongPositionState
 
-	opl2 *opl2.Chip
-	s    *sampler.Sampler
+	opl2           *opl2.Chip
+	s              *sampler.Sampler
+	rowRenderState *rowRenderState
 }
 
 // NewManager creates a new manager for an S3M song

--- a/internal/format/s3m/playback/playback_textoutput.go
+++ b/internal/format/s3m/playback/playback_textoutput.go
@@ -41,7 +41,7 @@ func s3mChannelRender(cdata render.ChannelData) string {
 	return strings.Join([]string{n, i, v, e}, " ")
 }
 
-func (m *Manager) getRowText() render.RowDisplay {
+func (m *Manager) getRowText() *render.RowDisplay {
 	nCh := 0
 	for ch := range m.channels {
 		if !m.song.IsChannelEnabled(ch) {
@@ -49,7 +49,7 @@ func (m *Manager) getRowText() render.RowDisplay {
 		}
 		nCh++
 	}
-	var rowText = render.NewRowText(nCh, s3mChannelRender)
+	rowText := render.NewRowText(nCh, s3mChannelRender)
 	for ch := range m.channels {
 		if !m.song.IsChannelEnabled(ch) {
 			continue
@@ -58,5 +58,5 @@ func (m *Manager) getRowText() render.RowDisplay {
 
 		rowText.Channels[ch] = cs.Cmd
 	}
-	return rowText
+	return &rowText
 }

--- a/internal/format/xm/playback/playback.go
+++ b/internal/format/xm/playback/playback.go
@@ -37,6 +37,8 @@ type Manager struct {
 
 	opl2 *opl2.Chip
 	s    *sampler.Sampler
+
+	rowRenderState *rowRenderState
 }
 
 // NewManager creates a new manager for an XM song

--- a/internal/format/xm/playback/playback_textoutput.go
+++ b/internal/format/xm/playback/playback_textoutput.go
@@ -55,7 +55,7 @@ func xmChannelRender(cdata render.ChannelData) string {
 	return strings.Join([]string{n, i, v, e}, " ")
 }
 
-func (m *Manager) getRowText() render.RowDisplay {
+func (m *Manager) getRowText() *render.RowDisplay {
 	nCh := 0
 	for ch := range m.channels {
 		if !m.song.IsChannelEnabled(ch) {
@@ -63,7 +63,7 @@ func (m *Manager) getRowText() render.RowDisplay {
 		}
 		nCh++
 	}
-	var rowText = render.NewRowText(nCh, xmChannelRender)
+	rowText := render.NewRowText(nCh, xmChannelRender)
 	for ch := range m.channels {
 		if !m.song.IsChannelEnabled(ch) {
 			continue
@@ -72,5 +72,5 @@ func (m *Manager) getRowText() render.RowDisplay {
 
 		rowText.Channels[ch] = cs.Cmd
 	}
-	return rowText
+	return &rowText
 }

--- a/internal/player/render/render.go
+++ b/internal/player/render/render.go
@@ -42,8 +42,8 @@ func (rt RowDisplay) String(options ...interface{}) string {
 
 //RowRender is the final output of a single row's data
 type RowRender struct {
-	Stop    bool
 	Order   int
 	Row     int
-	RowText RowDisplay
+	Tick    int
+	RowText *RowDisplay
 }

--- a/internal/player/state/channel.go
+++ b/internal/player/state/channel.go
@@ -133,7 +133,7 @@ func (cs *ChannelState) ProcessRow(row intf.Row, channel intf.ChannelData, globa
 }
 
 // RenderRowTick renders a channel's row data for a single tick
-func (cs *ChannelState) RenderRowTick(tick int, lastTick bool, mixerData []mixing.Data, ch int, ticksThisRow int, mix *mixing.Mixer, panmixer mixing.PanMixer, samplerSpeed float32, tickSamples int, centerPanning volume.Matrix, tickDuration time.Duration) {
+func (cs *ChannelState) RenderRowTick(tick int, lastTick bool, mixerData *mixing.Data, ch int, ticksThisRow int, mix *mixing.Mixer, panmixer mixing.PanMixer, samplerSpeed float32, tickSamples int, centerPanning volume.Matrix, tickDuration time.Duration) {
 	if cs.Command != nil {
 		cs.Command(ch, cs, tick, lastTick)
 	}
@@ -157,7 +157,7 @@ func (cs *ChannelState) RenderRowTick(tick int, lastTick bool, mixerData []mixin
 		}
 		data.MixInSample(mixData)
 		cs.Pos.Add(samplerAdd * float32(tickSamples))
-		mixerData[tick] = mixing.Data{
+		*mixerData = mixing.Data{
 			Data:       data,
 			Pan:        cs.Pan,
 			Volume:     volume.Volume(1.0),


### PR DESCRIPTION
- rendered audio data is now calculated for a single tick and fed into the output stream. This is more computationally intensive, but ends up being good for sound cards, as they are now much less likely to get underflowed on output data.