### PR TITLE
OPL2 fixup

### DIFF
--- a/internal/format/s3m/layout/channel/opl2intf.go
+++ b/internal/format/s3m/layout/channel/opl2intf.go
@@ -17,6 +17,5 @@ type OPL2Intf interface {
 
 // NewOPL2Chip generates a new OPL2 chip
 func NewOPL2Chip(rate uint32) OPL2Chip {
-	//return opl2.NewGMEmu(rate)
 	return opl2.NewChip(rate, false)
 }

--- a/internal/format/s3m/layout/channel/opl2intf.go
+++ b/internal/format/s3m/layout/channel/opl2intf.go
@@ -4,7 +4,19 @@ import (
 	"github.com/gotracker/opl2"
 )
 
+// OPL2Chip sets up a contract that the chip definition will contain these interfaces
+type OPL2Chip interface {
+	WriteReg(uint32, uint8)
+	GenerateBlock2(uint, []int32)
+}
+
 // OPL2Intf is an interface to get the active OPL2 chip
 type OPL2Intf interface {
-	GetOPL2Chip() *opl2.Chip
+	GetOPL2Chip() OPL2Chip
+}
+
+// NewOPL2Chip generates a new OPL2 chip
+func NewOPL2Chip(rate uint32) OPL2Chip {
+	//return opl2.NewGMEmu(rate)
+	return opl2.NewChip(rate, false)
 }

--- a/internal/format/s3m/layout/instrument.go
+++ b/internal/format/s3m/layout/instrument.go
@@ -18,6 +18,7 @@ type InstrumentDataIntf interface {
 
 	Initialize(*InstrumentOnChannel) error
 	SetKeyOn(*InstrumentOnChannel, note.Period, bool)
+	NoteCut(*InstrumentOnChannel)
 	GetKeyOn(*InstrumentOnChannel) bool
 	Update(*InstrumentOnChannel, time.Duration)
 }
@@ -168,6 +169,13 @@ func (inst *InstrumentOnChannel) GetInstrument() intf.Instrument {
 func (inst *InstrumentOnChannel) SetKeyOn(period note.Period, on bool) {
 	if inst.Instrument != nil && inst.Instrument.Inst != nil {
 		inst.Instrument.Inst.SetKeyOn(inst, period, on)
+	}
+}
+
+// NoteCut cuts the current playback of the instrument
+func (inst *InstrumentOnChannel) NoteCut() {
+	if inst.Instrument != nil && inst.Instrument.Inst != nil {
+		inst.Instrument.Inst.NoteCut(inst)
 	}
 }
 

--- a/internal/format/s3m/layout/instrument_opl2.go
+++ b/internal/format/s3m/layout/instrument_opl2.go
@@ -87,7 +87,7 @@ type InstrumentOPL2 struct {
 }
 
 type ym3812 struct {
-	chip  *opl2.Chip
+	chip  channel.OPL2Chip
 	regB0 uint8
 }
 

--- a/internal/format/s3m/layout/instrument_pcm.go
+++ b/internal/format/s3m/layout/instrument_pcm.go
@@ -116,9 +116,13 @@ func (inst *InstrumentPCM) SetKeyOn(ioc *InstrumentOnChannel, period note.Period
 
 // GetKeyOn gets the key on flag for the instrument
 func (inst *InstrumentPCM) GetKeyOn(ioc *InstrumentOnChannel) bool {
-	return false
+	return true
 }
 
 // Update advances time by the amount specified by `tickDuration`
 func (inst *InstrumentPCM) Update(ioc *InstrumentOnChannel, tickDuration time.Duration) {
+}
+
+// NoteCut cuts the current playback of the instrument
+func (inst *InstrumentPCM) NoteCut(ioc *InstrumentOnChannel) {
 }

--- a/internal/format/s3m/playback/effect/effect_notedelay.go
+++ b/internal/format/s3m/playback/effect/effect_notedelay.go
@@ -11,13 +11,12 @@ type NoteDelay uint8 // 'SDx'
 
 // PreStart triggers when the effect enters onto the channel state
 func (e NoteDelay) PreStart(cs intf.Channel, p intf.Playback) {
+	cs.SetNotePlayTick(int(uint8(e) & 0x0F))
 }
 
 // Start triggers on the first tick, but before the Tick() function is called
 func (e NoteDelay) Start(cs intf.Channel, p intf.Playback) {
 	cs.ResetRetriggerCount()
-
-	cs.SetNotePlayTick(int(uint8(e) & 0x0F))
 }
 
 // Tick is called on every tick

--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gotracker/gomixing/sampling"
 	"github.com/gotracker/gomixing/volume"
 	device "github.com/gotracker/gosound"
-	"github.com/gotracker/opl2"
 
 	"gotracker/internal/format/s3m/layout"
 	"gotracker/internal/format/s3m/layout/channel"
@@ -35,7 +34,7 @@ type Manager struct {
 	preMixRowTxn  intf.SongPositionState
 	postMixRowTxn intf.SongPositionState
 
-	opl2           *opl2.Chip
+	opl2           channel.OPL2Chip
 	s              *sampler.Sampler
 	rowRenderState *rowRenderState
 }
@@ -237,7 +236,7 @@ func (m *Manager) GetName() string {
 }
 
 // GetOPL2Chip returns the current song's OPL2 chip, if it's needed
-func (m *Manager) GetOPL2Chip() *opl2.Chip {
+func (m *Manager) GetOPL2Chip() channel.OPL2Chip {
 	return m.opl2
 }
 

--- a/internal/format/s3m/playback/playback_render.go
+++ b/internal/format/s3m/playback/playback_render.go
@@ -8,8 +8,8 @@ import (
 	"github.com/gotracker/gomixing/panning"
 	"github.com/gotracker/gomixing/volume"
 	device "github.com/gotracker/gosound"
-	"github.com/gotracker/opl2"
 
+	"gotracker/internal/format/s3m/layout/channel"
 	"gotracker/internal/format/s3m/playback/effect"
 	"gotracker/internal/format/s3m/playback/util"
 	"gotracker/internal/player/intf"
@@ -226,7 +226,7 @@ func (m *Manager) renderOPL2RowTick(tick int, mixerData *mixing.Data, ticksThisR
 }
 
 func (m *Manager) setOPL2Chip(rate uint32) {
-	m.opl2 = opl2.NewChip(rate, false)
+	m.opl2 = channel.NewOPL2Chip(rate)
 	m.opl2.WriteReg(0x01, 0x20) // enable all waveforms
 	m.opl2.WriteReg(0x04, 0x00) // clear timer flags
 	m.opl2.WriteReg(0x08, 0x40) // clear CSW and set NOTE-SEL

--- a/internal/format/s3m/playback/playback_textoutput.go
+++ b/internal/format/s3m/playback/playback_textoutput.go
@@ -33,7 +33,7 @@ func s3mChannelRender(cdata render.ChannelData) string {
 			}
 		}
 
-		if data.HasCommand() {
+		if data.HasCommand() && data.Command != 0 {
 			e = fmt.Sprintf("%c%0.2X", '@'+data.Command, data.Info)
 		}
 	}

--- a/internal/format/xm/layout/instrument.go
+++ b/internal/format/xm/layout/instrument.go
@@ -18,6 +18,7 @@ type InstrumentDataIntf interface {
 
 	Initialize(*InstrumentOnChannel) error
 	SetKeyOn(*InstrumentOnChannel, note.Period, bool)
+	NoteCut(*InstrumentOnChannel)
 	GetKeyOn(*InstrumentOnChannel) bool
 	Update(*InstrumentOnChannel, time.Duration)
 }
@@ -169,6 +170,13 @@ func (inst *InstrumentOnChannel) GetInstrument() intf.Instrument {
 func (inst *InstrumentOnChannel) SetKeyOn(period note.Period, on bool) {
 	if inst.Instrument != nil && inst.Instrument.Inst != nil {
 		inst.Instrument.Inst.SetKeyOn(inst, period, on)
+	}
+}
+
+// NoteCut cuts the current playback of the instrument
+func (inst *InstrumentOnChannel) NoteCut() {
+	if inst.Instrument != nil && inst.Instrument.Inst != nil {
+		inst.Instrument.Inst.NoteCut(inst)
 	}
 }
 

--- a/internal/format/xm/layout/instrument_opl2.go
+++ b/internal/format/xm/layout/instrument_opl2.go
@@ -134,6 +134,12 @@ func (inst *InstrumentOPL2) SetKeyOn(ioc *InstrumentOnChannel, period note.Perio
 	}
 }
 
+// NoteCut cuts the current playback of the instrument
+func (inst *InstrumentOPL2) NoteCut(ioc *InstrumentOnChannel) {
+	ioc.Volume = 0
+	inst.SetKeyOn(ioc, 0, false)
+}
+
 func (inst *InstrumentOPL2) getReg20(o *OPL2OperatorData) uint8 {
 	reg20 := uint8(0x00)
 	if o.Tremolo {

--- a/internal/format/xm/layout/instrument_pcm.go
+++ b/internal/format/xm/layout/instrument_pcm.go
@@ -117,9 +117,13 @@ func (inst *InstrumentPCM) Initialize(ioc *InstrumentOnChannel) error {
 func (inst *InstrumentPCM) SetKeyOn(ioc *InstrumentOnChannel, period note.Period, on bool) {
 }
 
+// NoteCut cuts the current playback of the instrument
+func (inst *InstrumentPCM) NoteCut(ioc *InstrumentOnChannel) {
+}
+
 // GetKeyOn gets the key on flag for the instrument
 func (inst *InstrumentPCM) GetKeyOn(ioc *InstrumentOnChannel) bool {
-	return false
+	return true
 }
 
 // Update advances time by the amount specified by `tickDuration`

--- a/internal/format/xm/playback/effect/effect_notedelay.go
+++ b/internal/format/xm/playback/effect/effect_notedelay.go
@@ -11,13 +11,12 @@ type NoteDelay uint8 // 'EDx'
 
 // PreStart triggers when the effect enters onto the channel state
 func (e NoteDelay) PreStart(cs intf.Channel, p intf.Playback) {
+	cs.SetNotePlayTick(int(uint8(e) & 0x0F))
 }
 
 // Start triggers on the first tick, but before the Tick() function is called
 func (e NoteDelay) Start(cs intf.Channel, p intf.Playback) {
 	cs.ResetRetriggerCount()
-
-	cs.SetNotePlayTick(int(uint8(e) & 0x0F))
 }
 
 // Tick is called on every tick

--- a/internal/format/xm/playback/playback_command.go
+++ b/internal/format/xm/playback/playback_command.go
@@ -46,12 +46,12 @@ func (m *Manager) processEffect(ch int, cs *state.ChannelState, currentTick int,
 	// post-effect
 	m.doNoteVolCalcs(cs)
 
-	if cs.TargetPeriod == 0 && cs.Instrument != nil && cs.Instrument.GetKeyOn() {
-		if cs.Cmd.GetNote() == note.StopNote {
-			cs.Instrument.SetVolume(0)
-		}
-		cs.Instrument.SetKeyOn(cs.Period, false)
-	} else if cs.DoRetriggerNote && currentTick == cs.NotePlayTick {
+	n := note.EmptyNote
+	if cs.Cmd != nil {
+		n = cs.Cmd.GetNote()
+	}
+	keyOff := n.IsEmpty() || n.IsStop()
+	if cs.DoRetriggerNote && cs.TargetPeriod != 0 && currentTick == cs.NotePlayTick {
 		cs.Instrument = nil
 		if cs.TargetInst != nil {
 			if cs.PrevInstrument != nil && cs.PrevInstrument.GetInstrument() == cs.TargetInst {
@@ -67,8 +67,19 @@ func (m *Manager) processEffect(ch int, cs *state.ChannelState, currentTick int,
 		}
 		cs.Period = cs.TargetPeriod
 		cs.Pos = cs.TargetPos
-		if cs.Period != 0 && cs.Instrument != nil {
+		if cs.Instrument != nil {
 			cs.Instrument.SetKeyOn(cs.Period, true)
+			keyOff = false
+		}
+	}
+
+	if keyOff && cs.Instrument != nil && cs.Instrument.GetKeyOn() {
+		if n == note.StopNote {
+			cs.Instrument.NoteCut()
+			cs.Instrument = nil
+			cs.Period = 0
+		} else {
+			cs.Instrument.SetKeyOn(cs.Period, false)
 		}
 	}
 }

--- a/internal/player/intf/instrument.go
+++ b/internal/player/intf/instrument.go
@@ -32,6 +32,7 @@ type InstrumentOnChannel interface {
 
 	GetInstrument() Instrument
 	SetKeyOn(note.Period, bool)
+	NoteCut()
 	GetKeyOn() bool
 	Update(time.Duration)
 	SetFilter(Filter)

--- a/internal/player/state/channel.go
+++ b/internal/player/state/channel.go
@@ -145,13 +145,12 @@ func (cs *ChannelState) RenderRowTick(tick int, lastTick bool, mixerData *mixing
 	sample := cs.Instrument
 	if sample != nil && cs.Period != 0 && !cs.PlaybackFrozen() {
 		sample.SetVolume(cs.ActiveVolume * cs.LastGlobalVolume)
-		// make a stand-alone data buffer for this channel for this tick
-		data := mix.NewMixBuffer(tickSamples)
-
 		period := cs.Period + cs.VibratoDelta
 		sample.SetPeriod(period)
 		samplerAdd := samplerSpeed / float32(period)
 		sample.Update(tickDuration)
+		// make a stand-alone data buffer for this channel for this tick
+		data := mix.NewMixBuffer(tickSamples)
 		mixData := mixing.SampleMixIn{
 			Sample:    sampling.NewSampler(sample, cs.Pos, samplerAdd),
 			StaticVol: volume.Volume(1.0),


### PR DESCRIPTION
- fixes a series of issues with OPL2 that also crept into PCM playback related to note cut and key-off.
- added simpler way to change out the OPL2/3 chip simulator
- different way to calculate FNum/Block in OPL2
