### PR TITLE
Various fixes for S3M and XM

### DIFF
--- a/internal/format/internal/util/loopdetect.go
+++ b/internal/format/internal/util/loopdetect.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"gotracker/internal/player/intf"
+)
+
+type loopDetectSequence struct {
+	min intf.RowIdx
+	max intf.RowIdx
+}
+
+type loopDetectNode map[intf.RowIdx]bool
+
+// LoopDetect is a poorly-optimized, but simple loop detection system for tracked music
+type LoopDetect struct {
+	orders map[intf.OrderIdx]*loopDetectNode
+}
+
+// Observe determines if a particular order+row combination has been observed before and returns true if it has
+// it will also add the combination to the detection tree if it has not been observed before.
+func (ld *LoopDetect) Observe(ord intf.OrderIdx, row intf.RowIdx) bool {
+	n := ld.findOrAddOrder(ord)
+
+	if *n == nil {
+		*n = make(loopDetectNode)
+	}
+
+	if _, found := (*n)[row]; found {
+		return true
+	}
+
+	(*n)[row] = true
+	return false
+}
+
+func (ld *LoopDetect) findOrAddOrder(ord intf.OrderIdx) *loopDetectNode {
+	if ld.orders == nil {
+		ld.orders = make(map[intf.OrderIdx]*loopDetectNode)
+	}
+
+	if n, ok := ld.orders[ord]; ok && n != nil {
+		return n
+	}
+
+	n := loopDetectNode{}
+	ld.orders[ord] = &n
+
+	return &n
+}

--- a/internal/format/s3m/layout/channel/memory.go
+++ b/internal/format/s3m/layout/channel/memory.go
@@ -10,6 +10,8 @@ type Memory struct {
 	lastNonZero   uint8
 	patternLoop   PatternLoop
 
+	VolSlideEveryFrame bool
+
 	tremorMem         Tremor
 	vibratoOscillator Oscillator
 	tremoloOscillator Oscillator
@@ -72,10 +74,6 @@ func (m *Memory) TremoloOscillator() *Oscillator {
 
 // Retrigger runs certain operations when a note is retriggered
 func (m *Memory) Retrigger() {
-	if m.vibratoOscillator.Pos != 0 {
-		a := 0
-		a++
-	}
 	m.vibratoOscillator.Pos = 0
 	m.tremoloOscillator.Pos = 0
 }

--- a/internal/format/s3m/layout/channel/memory.go
+++ b/internal/format/s3m/layout/channel/memory.go
@@ -3,7 +3,10 @@ package channel
 // Memory is the storage object for custom effect/command values
 type Memory struct {
 	portaToNote   uint8
-	vibrato       uint8
+	vibratoSpeed  uint8
+	vibratoDepth  uint8
+	tremoloSpeed  uint8
+	tremoloDepth  uint8
 	sampleOffset  uint8
 	tempoDecrease uint8
 	tempoIncrease uint8
@@ -33,8 +36,19 @@ func (m *Memory) PortaToNote(input uint8) uint8 {
 }
 
 // Vibrato gets or sets the most recent non-zero value (or input) for Vibrato
-func (m *Memory) Vibrato(input uint8) uint8 {
-	return m.getEffectMemory(input, &m.vibrato)
+func (m *Memory) Vibrato(input uint8) (uint8, uint8) {
+	// vibrato is unusual, because each nibble is treated uniquely
+	vx := m.getEffectMemory(input>>4, &m.vibratoSpeed)
+	vy := m.getEffectMemory(input&0x0f, &m.vibratoDepth)
+	return vx, vy
+}
+
+// Tremolo gets or sets the most recent non-zero value (or input) for Vibrato
+func (m *Memory) Tremolo(input uint8) (uint8, uint8) {
+	// tremolo is unusual, because each nibble is treated uniquely
+	vx := m.getEffectMemory(input>>4, &m.tremoloSpeed)
+	vy := m.getEffectMemory(input&0x0f, &m.tremoloDepth)
+	return vx, vy
 }
 
 // SampleOffset gets or sets the most recent non-zero value (or input) for Sample Offset
@@ -74,8 +88,9 @@ func (m *Memory) TremoloOscillator() *Oscillator {
 
 // Retrigger runs certain operations when a note is retriggered
 func (m *Memory) Retrigger() {
-	m.vibratoOscillator.Pos = 0
-	m.tremoloOscillator.Pos = 0
+	for _, osc := range []*Oscillator{m.VibratoOscillator(), m.TremoloOscillator()} {
+		osc.Reset()
+	}
 }
 
 // GetPatternLoop returns the pattern loop object from the memory

--- a/internal/format/s3m/layout/channel/oscillator.go
+++ b/internal/format/s3m/layout/channel/oscillator.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"math"
 	"math/rand"
 
 	formatutil "gotracker/internal/format/internal/util"
@@ -23,7 +24,7 @@ const (
 // Oscillator is an oscillator
 type Oscillator struct {
 	Table WaveTableSelect
-	Pos   int8
+	Pos   uint8
 }
 
 // GetWave returns the wave amplitude for the current position
@@ -36,11 +37,7 @@ func (o *Oscillator) GetWave(depth float32) float32 {
 		vib = (32.0 - float32(o.Pos&0x3f)) / 32.0
 	case WaveTableSelectSquare:
 		v := formatutil.GetProtrackerSine(int(o.Pos))
-		if v > 0 {
-			vib = 1.0
-		} else {
-			vib = -1.0
-		}
+		vib = float32(math.Copysign(1, float64(v)))
 	case WaveTableSelectRandom:
 		vib = formatutil.GetProtrackerSine(rand.Int() & 0x3f)
 	}
@@ -50,10 +47,7 @@ func (o *Oscillator) GetWave(depth float32) float32 {
 
 // Advance advances the oscillator position by the specified amount
 func (o *Oscillator) Advance(speed int) {
-	o.Pos += int8(speed)
-	for o.Pos < 0 {
-		o.Pos += 64
-	}
+	o.Pos += uint8(speed)
 	for o.Pos > 63 {
 		o.Pos -= 64
 	}

--- a/internal/format/s3m/load/modconv/modconverter.go
+++ b/internal/format/s3m/load/modconv/modconverter.go
@@ -310,7 +310,6 @@ func Read(r io.Reader) (*s3mfile.File, error) {
 			f.ChannelSettings[i] = s3mfile.MakeChannelSetting(true, s3mfile.ChannelCategoryPCMRight, i>>1)
 			f.Panning[i] = s3mfile.DefaultPanningRight
 		}
-
 	}
 
 	f.Patterns = make([]s3mfile.PackedPattern, f.Head.PatternCount)

--- a/internal/format/s3m/playback/effect/effect_finevibrato.go
+++ b/internal/format/s3m/playback/effect/effect_finevibrato.go
@@ -23,12 +23,12 @@ func (e FineVibrato) Start(cs intf.Channel, p intf.Playback) {
 // Tick is called on every tick
 func (e FineVibrato) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
-	xy := mem.Vibrato(uint8(e))
-	// NOTE: JBC - S3M updates on tick 0, but MOD does not.
+	x, y := mem.Vibrato(uint8(e))
+	// NOTE: JBC - S3M dos not update on tick 0, but MOD does.
 	// Maybe need to add a flag for converted MOD backward compatibility?
-	x := xy >> 4
-	y := xy & 0x0f
-	doVibrato(cs, currentTick, x, y, 1)
+	if currentTick != 0 {
+		doVibrato(cs, currentTick, x, y, 1)
+	}
 }
 
 // Stop is called on the last tick of the row, but after the Tick() function is called

--- a/internal/format/s3m/playback/effect/effect_portatonote.go
+++ b/internal/format/s3m/playback/effect/effect_portatonote.go
@@ -30,7 +30,8 @@ func (e PortaToNote) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
 	xx := mem.PortaToNote(uint8(e))
 
-	period := cs.GetPeriod()
+	// vibrato modifies current period for portamento
+	period := cs.GetPeriod().Add(cs.GetVibratoDelta())
 	ptp := cs.GetPortaTargetPeriod()
 	if currentTick != 0 {
 		if note.ComparePeriods(period, ptp) == 1 {

--- a/internal/format/s3m/playback/effect/effect_tremolo.go
+++ b/internal/format/s3m/playback/effect/effect_tremolo.go
@@ -22,12 +22,12 @@ func (e Tremolo) Start(cs intf.Channel, p intf.Playback) {
 // Tick is called on every tick
 func (e Tremolo) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
-	xy := mem.LastNonZero(uint8(e))
-	// NOTE: JBC - S3M updates on tick 0, but MOD does not.
+	x, y := mem.Tremolo(uint8(e))
+	// NOTE: JBC - S3M dos not update on tick 0, but MOD does.
 	// Maybe need to add a flag for converted MOD backward compatibility?
-	x := xy >> 4
-	y := xy & 0x0f
-	doTremolo(cs, currentTick, x, y, 4)
+	if currentTick != 0 {
+		doTremolo(cs, currentTick, x, y, 4)
+	}
 }
 
 // Stop is called on the last tick of the row, but after the Tick() function is called

--- a/internal/format/s3m/playback/effect/effect_vibrato.go
+++ b/internal/format/s3m/playback/effect/effect_vibrato.go
@@ -23,12 +23,10 @@ func (e Vibrato) Start(cs intf.Channel, p intf.Playback) {
 // Tick is called on every tick
 func (e Vibrato) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
-	xy := mem.Vibrato(uint8(e))
+	x, y := mem.Vibrato(uint8(e))
 	// NOTE: JBC - S3M dos not update on tick 0, but MOD does.
 	// Maybe need to add a flag for converted MOD backward compatibility?
-	if currentTick == 0 {
-		x := xy >> 4
-		y := xy & 0x0f
+	if currentTick != 0 {
 		doVibrato(cs, currentTick, x, y, 4)
 	}
 }

--- a/internal/format/s3m/playback/effect/effect_vibrato.go
+++ b/internal/format/s3m/playback/effect/effect_vibrato.go
@@ -24,11 +24,13 @@ func (e Vibrato) Start(cs intf.Channel, p intf.Playback) {
 func (e Vibrato) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
 	xy := mem.Vibrato(uint8(e))
-	// NOTE: JBC - S3M updates on tick 0, but MOD does not.
+	// NOTE: JBC - S3M dos not update on tick 0, but MOD does.
 	// Maybe need to add a flag for converted MOD backward compatibility?
-	x := xy >> 4
-	y := xy & 0x0f
-	doVibrato(cs, currentTick, x, y, 4)
+	if currentTick == 0 {
+		x := xy >> 4
+		y := xy & 0x0f
+		doVibrato(cs, currentTick, x, y, 4)
+	}
 }
 
 // Stop is called on the last tick of the row, but after the Tick() function is called

--- a/internal/format/s3m/playback/effect/effect_volslide.go
+++ b/internal/format/s3m/playback/effect/effect_volslide.go
@@ -27,13 +27,11 @@ func (e VolumeSlide) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	y := uint8(xy & 0x0F)
 
 	if x == 0 { // decrease every tick
-		if y == 0x0F {
-			doVolSlide(cs, -float32(y), 1.0)
-		} else if currentTick != 0 {
+		if mem.VolSlideEveryFrame || currentTick != 0 {
 			doVolSlide(cs, -float32(y), 1.0)
 		}
 	} else if y == 0 { // increase every tick
-		if currentTick != 0 {
+		if mem.VolSlideEveryFrame || currentTick != 0 {
 			doVolSlide(cs, float32(x), 1.0)
 		}
 	} else if x == 0x0F { // finely decrease on the first tick

--- a/internal/format/s3m/playback/effect/util.go
+++ b/internal/format/s3m/playback/effect/util.go
@@ -80,8 +80,8 @@ func doPortaDownToNote(cs intf.Channel, amount float32, multiplier float32, targ
 
 func doVibrato(cs intf.Channel, currentTick int, speed uint8, depth uint8, multiplier float32) {
 	mem := cs.GetMemory().(*channel.Memory)
-	delta := note.PeriodDelta(calculateWaveTable(cs, currentTick, speed, depth, multiplier, mem.VibratoOscillator()))
-	cs.SetVibratoDelta(delta)
+	delta := calculateWaveTable(cs, currentTick, speed, depth, multiplier, mem.VibratoOscillator())
+	cs.SetVibratoDelta(note.PeriodDelta(delta))
 }
 
 func doTremor(cs intf.Channel, currentTick int, onTicks int, offTicks int) {

--- a/internal/format/s3m/playback/effect/util.go
+++ b/internal/format/s3m/playback/effect/util.go
@@ -140,7 +140,7 @@ func doTremolo(cs intf.Channel, currentTick int, speed uint8, depth uint8, multi
 }
 
 func calculateWaveTable(cs intf.Channel, currentTick int, speed uint8, depth uint8, multiplier float32, o *channel.Oscillator) float32 {
-	delta := o.GetWave(float32(depth) * multiplier)
+	delta := o.GetWave(float32(depth)) * multiplier
 	o.Advance(int(speed))
 	return delta
 }

--- a/internal/format/s3m/playback/filter/amigafilter.go
+++ b/internal/format/s3m/playback/filter/amigafilter.go
@@ -29,7 +29,6 @@ var (
 	amigaLPFCoeffA0 volume.Volume = 1.0
 	amigaLPFCoeffA1 volume.Volume = volume.Volume(math.Sqrt(2.0))
 	amigaLPFCoeffA2 volume.Volume = 1.0
-	amigaLPFDen     volume.Volume = amigaLPFCoeffA0 + amigaLPFCoeffA1 + amigaLPFCoeffA1
 
 	amigaLPFCoeffB0 volume.Volume = 1.0
 	amigaLPFCoeffB1 volume.Volume = 0.0
@@ -46,7 +45,7 @@ func (f *AmigaLPF) Filter(dry volume.Matrix) volume.Matrix {
 		c := &f.channels[i]
 		xn := s
 		//yn := amigaLPFCoeffA0*xn + amigaLPFCoeffA1*c.xnz1 + amigaLPFCoeffA2*c.xnz2 - amigaLPFCoeffB1*c.ynz1 - amigaLPFCoeffB2*c.ynz2
-		yn := (xn + amigaLPFCoeffA1*c.xnz1 + c.xnz2) / amigaLPFDen // since B1 and B2 are 0, they simplify out.  Similarly, the multiply on A0 and A2 become simpler.
+		yn := (xn + amigaLPFCoeffA1*c.xnz1 + c.xnz2) / 3 // since B1 and B2 are 0, they simplify out.  Similarly, the multiply on A0 and A2 become simpler.
 
 		c.xnz2 = c.xnz1
 		c.xnz1 = xn

--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -181,14 +181,14 @@ func (m *Manager) DisableFeatures(features []feature.Feature) {
 	for _, f := range features {
 		switch f {
 		case feature.OrderLoop:
-			m.pattern.OrderLoopEnabled = false
+			m.pattern.SongLoopEnabled = false
 		}
 	}
 }
 
 // CanOrderLoop returns true if the song is allowed to order loop
 func (m *Manager) CanOrderLoop() bool {
-	return m.pattern.OrderLoopEnabled
+	return m.pattern.SongLoopEnabled
 }
 
 // GetSongData gets the song data object

--- a/internal/format/s3m/playback/playback_command.go
+++ b/internal/format/s3m/playback/playback_command.go
@@ -27,10 +27,6 @@ func (m *Manager) doNoteVolCalcs(cs *state.ChannelState) {
 }
 
 func (m *Manager) processCommand(ch int, cs *state.ChannelState, currentTick int, lastTick bool) {
-	if currentTick == 0 {
-		mem := cs.GetMemory().(*channel.Memory)
-		mem.Retrigger()
-	}
 	// pre-effect
 	m.doNoteVolCalcs(cs)
 	if cs.ActiveEffect != nil {
@@ -71,6 +67,8 @@ func (m *Manager) processCommand(ch int, cs *state.ChannelState, currentTick int
 			cs.LastGlobalVolume = m.GetGlobalVolume()
 			cs.Instrument.Attack()
 			keyOff = false
+			mem := cs.GetMemory().(*channel.Memory)
+			mem.Retrigger()
 		}
 	}
 

--- a/internal/format/s3m/playback/playback_command.go
+++ b/internal/format/s3m/playback/playback_command.go
@@ -27,6 +27,10 @@ func (m *Manager) doNoteVolCalcs(cs *state.ChannelState) {
 }
 
 func (m *Manager) processCommand(ch int, cs *state.ChannelState, currentTick int, lastTick bool) {
+	if currentTick == 0 {
+		mem := cs.GetMemory().(*channel.Memory)
+		mem.Retrigger()
+	}
 	// pre-effect
 	m.doNoteVolCalcs(cs)
 	if cs.ActiveEffect != nil {
@@ -67,8 +71,6 @@ func (m *Manager) processCommand(ch int, cs *state.ChannelState, currentTick int
 			cs.LastGlobalVolume = m.GetGlobalVolume()
 			cs.Instrument.Attack()
 			keyOff = false
-			mem := cs.GetMemory().(*channel.Memory)
-			mem.Retrigger()
 		}
 	}
 

--- a/internal/format/s3m/playback/playback_pattern.go
+++ b/internal/format/s3m/playback/playback_pattern.go
@@ -20,8 +20,8 @@ func (m *Manager) processPatternRow() error {
 	}
 
 	if m.pattern.NeedResetPatternLoops() {
-		for i := range m.channels {
-			mem := m.channels[i].GetMemory().(*channel.Memory)
+		for _, cs := range m.channels {
+			mem := cs.GetMemory().(*channel.Memory)
 			pl := mem.GetPatternLoop()
 			pl.Count = 0
 			pl.Enabled = false
@@ -31,6 +31,22 @@ func (m *Manager) processPatternRow() error {
 	pat := m.song.GetPattern(patIdx)
 	if pat == nil {
 		return intf.ErrStopSong
+	}
+
+	withinPatternLoop := false
+	for _, cs := range m.channels {
+		mem := cs.GetMemory().(*channel.Memory)
+		pl := mem.GetPatternLoop()
+		if pl.Enabled {
+			withinPatternLoop = true
+			break
+		}
+	}
+
+	if !withinPatternLoop {
+		if err := m.pattern.Observe(); err != nil {
+			return err
+		}
 	}
 
 	rows := pat.GetRows()

--- a/internal/format/xm/layout/channel/memory.go
+++ b/internal/format/xm/layout/channel/memory.go
@@ -142,10 +142,7 @@ func (m *Memory) TremoloOscillator() *Oscillator {
 // Retrigger runs certain operations when a note is retriggered
 func (m *Memory) Retrigger() {
 	for _, osc := range []*Oscillator{m.VibratoOscillator(), m.TremoloOscillator()} {
-		switch osc.Table {
-		case WaveTableSelectSineRetrigger, WaveTableSelectSawtoothRetrigger, WaveTableSelectSquareRetrigger, WaveTableSelectRandomRetrigger:
-			osc.Pos = 0
-		}
+		osc.Reset()
 	}
 }
 

--- a/internal/format/xm/layout/channel/oscillator.go
+++ b/internal/format/xm/layout/channel/oscillator.go
@@ -66,3 +66,21 @@ func (o *Oscillator) Advance(speed int) {
 		o.Pos -= 64
 	}
 }
+
+// Reset resets the position of the oscillator
+func (o *Oscillator) Reset(hard ...bool) {
+	hardReset := false
+	if len(hard) > 0 {
+		hardReset = hard[1]
+	}
+
+	doReset := hardReset
+	switch o.Table {
+	case WaveTableSelectSineRetrigger, WaveTableSelectSawtoothRetrigger, WaveTableSelectSquareRetrigger, WaveTableSelectRandomRetrigger:
+		doReset = true
+	}
+
+	if doReset {
+		o.Pos = 0
+	}
+}

--- a/internal/format/xm/playback/playback.go
+++ b/internal/format/xm/playback/playback.go
@@ -185,14 +185,14 @@ func (m *Manager) DisableFeatures(features []feature.Feature) {
 	for _, f := range features {
 		switch f {
 		case feature.OrderLoop:
-			m.pattern.OrderLoopEnabled = false
+			m.pattern.SongLoopEnabled = false
 		}
 	}
 }
 
 // CanOrderLoop returns true if the song is allowed to order loop
 func (m *Manager) CanOrderLoop() bool {
-	return m.pattern.OrderLoopEnabled
+	return m.pattern.SongLoopEnabled
 }
 
 // GetSongData gets the song data object

--- a/internal/format/xm/playback/playback_pattern.go
+++ b/internal/format/xm/playback/playback_pattern.go
@@ -20,8 +20,8 @@ func (m *Manager) processPatternRow() error {
 	}
 
 	if m.pattern.NeedResetPatternLoops() {
-		for i := range m.channels {
-			mem := m.channels[i].GetMemory().(*channel.Memory)
+		for _, cs := range m.channels {
+			mem := cs.GetMemory().(*channel.Memory)
 			pl := mem.GetPatternLoop()
 			pl.Count = 0
 			pl.Enabled = false
@@ -31,6 +31,22 @@ func (m *Manager) processPatternRow() error {
 	pat := m.song.GetPattern(patIdx)
 	if pat == nil {
 		return intf.ErrStopSong
+	}
+
+	withinPatternLoop := false
+	for _, cs := range m.channels {
+		mem := cs.GetMemory().(*channel.Memory)
+		pl := mem.GetPatternLoop()
+		if pl.Enabled {
+			withinPatternLoop = true
+			break
+		}
+	}
+
+	if !withinPatternLoop {
+		if err := m.pattern.Observe(); err != nil {
+			return err
+		}
 	}
 
 	rows := pat.GetRows()

--- a/internal/player/intf/channel.go
+++ b/internal/player/intf/channel.go
@@ -41,6 +41,7 @@ type Channel interface {
 	GetPeriod() note.Period
 	SetPeriod(note.Period)
 	SetVibratoDelta(note.PeriodDelta)
+	GetVibratoDelta() note.PeriodDelta
 	SetInstrument(Instrument)
 	GetInstrument() Instrument
 	GetTargetInst() Instrument

--- a/internal/player/state/channel.go
+++ b/internal/player/state/channel.go
@@ -253,6 +253,11 @@ func (cs *ChannelState) SetVibratoDelta(delta note.PeriodDelta) {
 	cs.VibratoDelta = delta
 }
 
+// GetVibratoDelta gets the vibrato (ephemeral) delta sampler period
+func (cs *ChannelState) GetVibratoDelta() note.PeriodDelta {
+	return cs.VibratoDelta
+}
+
 // SetVolumeActive enables or disables the sample of the instrument
 func (cs *ChannelState) SetVolumeActive(on bool) {
 	cs.volumeActive = on


### PR DESCRIPTION
- Changed song loop detection to be more accurate.
  - Songs that abuse row jump and order jump to extreme levels (such as `Ode to Protracker` and `Strobe Rev. 2`) will no longer unexpectedly trigger the end of the song playback when a loop occurs.
  - Additionally, the loop detection happens at time of row advancement, instead of at time of order advancement
- Added missing waveforms to S3M vibrato/tremolo
- Fixed S3M vibrato/fine-vibrato/tremolo advancement (was only ticking once per row, instead of expected N-1 ticks)
- Fixed S3M/MOD vibrato memory (each nibble is its own memory slot... weird)
- Added S3M/MOD tremolo memory patterned off vibrato memory
- Fixed Amiga Paula LPF simulation (wrong denominator - don't know what I was thinking before)
  - This should provide the correct dB/octave attenuation, now.
  - Still got the wrong omega value on sampling rates other than 44100Hz, but that's a problem for another day.