### PR TITLE
Player generalizations, part 3

### DIFF
--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -2,7 +2,6 @@ package playback
 
 import (
 	"github.com/gotracker/gomixing/panning"
-	"github.com/gotracker/gomixing/sampling"
 	device "github.com/gotracker/gosound"
 
 	"gotracker/internal/format/s3m/layout"
@@ -92,22 +91,13 @@ func (m *Manager) SetNumChannels(num int) {
 
 	for ch := range m.channels {
 		cs := &m.channels[ch]
-		cs.Pos = sampling.Pos{}
-		cs.PrevInstrument = nil
-		cs.Instrument = nil
-		cs.Period = nil
-		cs.Command = nil
+		cs.ResetStates()
 
-		cs.TargetPeriod = nil
-		cs.TargetPos = cs.Pos
-		cs.TargetInst = nil
 		cs.PortaTargetPeriod = nil
 		cs.NotePlayTick = 0
 		cs.RetriggerCount = 0
-		cs.VibratoDelta = 0
 		cs.TrackData = nil
 		cs.OutputChannelNum = m.song.GetOutputChannel(ch)
-		cs.SetVolumeActive(true)
 	}
 }
 

--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -34,7 +34,6 @@ type Manager struct {
 	OnEffect       func(intf.Effect)
 
 	chOrder [4][]intf.Channel
-	hasOPL2 bool
 }
 
 // NewManager creates a new manager for an S3M song
@@ -77,9 +76,6 @@ func NewManager(song *layout.Song) *Manager {
 		switch s3mfile.ChannelCategory(ch.Category) {
 		case s3mfile.ChannelCategoryUnknown:
 			// do nothing
-		case s3mfile.ChannelCategoryOPL2Melody, s3mfile.ChannelCategoryOPL2Drums:
-			m.hasOPL2 = true
-			fallthrough
 		default:
 			cIdx := int(ch.Category) - 1
 			m.chOrder[cIdx] = append(m.chOrder[cIdx], cs)
@@ -103,7 +99,10 @@ func (m *Manager) SetupSampler(samplesPerSecond int, channels int, bitsPerSample
 		return err
 	}
 
-	if m.hasOPL2 {
+	oplLen := len(m.chOrder[int(s3mfile.ChannelCategoryOPL2Melody)-1])
+	oplLen += len(m.chOrder[int(s3mfile.ChannelCategoryOPL2Drums)-1])
+
+	if oplLen > 0 {
 		m.ensureOPL2()
 	}
 	return nil

--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -33,8 +33,8 @@ type Manager struct {
 	rowRenderState *rowRenderState
 	OnEffect       func(intf.Effect)
 
-	chOrder  [4][]intf.Channel
-	needOPL2 bool
+	chOrder [4][]intf.Channel
+	hasOPL2 bool
 }
 
 // NewManager creates a new manager for an S3M song
@@ -78,7 +78,7 @@ func NewManager(song *layout.Song) *Manager {
 		case s3mfile.ChannelCategoryUnknown:
 			// do nothing
 		case s3mfile.ChannelCategoryOPL2Melody, s3mfile.ChannelCategoryOPL2Drums:
-			m.needOPL2 = true
+			m.hasOPL2 = true
 			fallthrough
 		default:
 			cIdx := int(ch.Category) - 1
@@ -103,7 +103,7 @@ func (m *Manager) SetupSampler(samplesPerSecond int, channels int, bitsPerSample
 		return err
 	}
 
-	if m.needOPL2 {
+	if m.hasOPL2 {
 		m.ensureOPL2()
 	}
 	return nil

--- a/internal/format/s3m/playback/playback_pattern.go
+++ b/internal/format/s3m/playback/playback_pattern.go
@@ -114,7 +114,7 @@ func (m *Manager) processPatternRow() error {
 		cs := &m.channels[channelNum]
 
 		m.processRowForChannel(cs)
-		cs.Process(row, m.GetGlobalVolume(), m.song)
+		cs.Process(row, m.song)
 	}
 
 	return nil

--- a/internal/format/s3m/playback/playback_pattern.go
+++ b/internal/format/s3m/playback/playback_pattern.go
@@ -105,16 +105,11 @@ func (m *Manager) processPatternRow() error {
 	m.rowRenderState.ticksThisRow = m.pattern.GetTicksThisRow()
 	m.rowRenderState.currentTick = 0
 
-	// run row processing, now that prestart has completed
-	for channelNum := range row.GetChannels() {
-		if channelNum >= m.GetNumChannels() {
-			continue
+	for _, order := range m.chOrder {
+		for _, cs := range order {
+			m.processRowForChannel(cs)
+			cs.Process(row, m.song)
 		}
-
-		cs := &m.channels[channelNum]
-
-		m.processRowForChannel(cs)
-		cs.Process(row, m.song)
 	}
 
 	return nil

--- a/internal/format/s3m/playback/playback_pattern.go
+++ b/internal/format/s3m/playback/playback_pattern.go
@@ -114,7 +114,7 @@ func (m *Manager) processPatternRow() error {
 		cs := &m.channels[channelNum]
 
 		m.processRowForChannel(cs)
-		cs.Process(row, m.GetGlobalVolume(), m.song, m.processCommand)
+		cs.Process(row, m.GetGlobalVolume(), m.song)
 	}
 
 	return nil

--- a/internal/format/s3m/playback/playback_render.go
+++ b/internal/format/s3m/playback/playback_render.go
@@ -92,9 +92,9 @@ func (m *Manager) soundRenderTick(premix *device.PremixData) error {
 				m.ensureOPL2()
 			}
 
-			rr, err := cs.RenderRowTick(tick, lastTick, ch,
-				m.rowRenderState.ticksThisRow,
-				m.rowRenderState.mix,
+			m.processCommand(ch, cs, tick, lastTick)
+
+			rr, err := cs.RenderRowTick(m.rowRenderState.mix,
 				m.rowRenderState.panmixer,
 				m.rowRenderState.samplerSpeed,
 				m.rowRenderState.samplesPerTick,

--- a/internal/format/s3m/playback/playback_render.go
+++ b/internal/format/s3m/playback/playback_render.go
@@ -3,7 +3,6 @@ package playback
 import (
 	"time"
 
-	s3mfile "github.com/gotracker/goaudiofile/music/tracked/s3m"
 	"github.com/gotracker/gomixing/mixing"
 	device "github.com/gotracker/gosound"
 
@@ -86,12 +85,6 @@ func (m *Manager) soundRenderTick(premix *device.PremixData) error {
 	for ch := range m.channels {
 		cs := &m.channels[ch]
 		if m.song.IsChannelEnabled(ch) {
-			chCat := m.song.ChannelSettings[ch].Category
-			switch chCat {
-			case s3mfile.ChannelCategoryOPL2Melody, s3mfile.ChannelCategoryOPL2Drums:
-				m.ensureOPL2()
-			}
-
 			m.processCommand(ch, cs, tick, lastTick)
 
 			rr, err := cs.RenderRowTick(m.rowRenderState.mix,

--- a/internal/format/xm/playback/playback.go
+++ b/internal/format/xm/playback/playback.go
@@ -1,7 +1,6 @@
 package playback
 
 import (
-	"github.com/gotracker/gomixing/sampling"
 	device "github.com/gotracker/gosound"
 
 	"gotracker/internal/format/xm/layout"
@@ -84,21 +83,13 @@ func (m *Manager) SetNumChannels(num int) {
 
 	for ch := range m.channels {
 		cs := &m.channels[ch]
-		cs.Pos = sampling.Pos{}
-		cs.PrevInstrument = nil
-		cs.Instrument = nil
-		cs.Period = nil
-		cs.Command = nil
+		cs.ResetStates()
 
-		cs.TargetPeriod = nil
-		cs.TargetPos = cs.Pos
-		cs.TargetInst = nil
+		cs.PortaTargetPeriod = nil
 		cs.NotePlayTick = 0
 		cs.RetriggerCount = 0
-		cs.VibratoDelta = 0
 		cs.TrackData = nil
 		cs.OutputChannelNum = m.song.GetOutputChannel(ch)
-		cs.SetVolumeActive(true)
 	}
 }
 

--- a/internal/format/xm/playback/playback_command.go
+++ b/internal/format/xm/playback/playback_command.go
@@ -71,6 +71,7 @@ func (m *Manager) processEffect(ch int, cs *state.ChannelState, currentTick int,
 			mem.Retrigger()
 		} else if keyOff {
 			nc.Release()
+			cs.SetPeriod(nil)
 		}
 	}
 }

--- a/internal/format/xm/playback/playback_pattern.go
+++ b/internal/format/xm/playback/playback_pattern.go
@@ -114,7 +114,7 @@ func (m *Manager) processPatternRow() error {
 		cs := &m.channels[channelNum]
 
 		m.processRowForChannel(cs)
-		cs.Process(row, m.GetGlobalVolume(), m.song)
+		cs.Process(row, m.song)
 	}
 
 	return nil

--- a/internal/format/xm/playback/playback_pattern.go
+++ b/internal/format/xm/playback/playback_pattern.go
@@ -114,7 +114,7 @@ func (m *Manager) processPatternRow() error {
 		cs := &m.channels[channelNum]
 
 		m.processRowForChannel(cs)
-		cs.Process(row, m.GetGlobalVolume(), m.song, m.processEffect)
+		cs.Process(row, m.GetGlobalVolume(), m.song)
 	}
 
 	return nil

--- a/internal/format/xm/playback/playback_render.go
+++ b/internal/format/xm/playback/playback_render.go
@@ -86,9 +86,10 @@ func (m *Manager) soundRenderTick(premix *device.PremixData) error {
 	for ch := range m.channels {
 		cs := &m.channels[ch]
 		if m.song.IsChannelEnabled(ch) {
-			rr, err := cs.RenderRowTick(tick, lastTick, ch,
-				m.rowRenderState.ticksThisRow,
-				m.rowRenderState.mix,
+
+			m.processEffect(ch, cs, tick, lastTick)
+
+			rr, err := cs.RenderRowTick(m.rowRenderState.mix,
 				m.rowRenderState.panmixer,
 				m.rowRenderState.samplerSpeed,
 				m.rowRenderState.samplesPerTick,

--- a/internal/player/intf/channel.go
+++ b/internal/player/intf/channel.go
@@ -27,6 +27,7 @@ type ChannelData interface {
 // Channel is an interface for channel state
 type Channel interface {
 	ResetRetriggerCount()
+	Process(Row, SongData)
 	SetMemory(Memory)
 	GetMemory() Memory
 	GetActiveVolume() volume.Volume

--- a/internal/player/intf/channel.go
+++ b/internal/player/intf/channel.go
@@ -42,8 +42,9 @@ type Channel interface {
 	SetPeriod(note.Period)
 	SetVibratoDelta(note.PeriodDelta)
 	GetVibratoDelta() note.PeriodDelta
-	SetInstrument(Instrument)
+	SetInstrument(Instrument, Playback)
 	GetInstrument() Instrument
+	GetNoteControl() NoteControl
 	GetTargetInst() Instrument
 	SetTargetInst(Instrument)
 	GetNoteSemitone() note.Semitone

--- a/internal/player/state/activechannel.go
+++ b/internal/player/state/activechannel.go
@@ -12,8 +12,8 @@ import (
 	"gotracker/internal/player/note"
 )
 
-// RenderState is the information needed to make an instrument play
-type RenderState struct {
+// renderState is the information needed to make an instrument play
+type renderState struct {
 	Instrument   intf.Instrument
 	Period       note.Period
 	Volume       volume.Volume
@@ -24,7 +24,7 @@ type RenderState struct {
 }
 
 // Reset sets the render state to defaults
-func (r *RenderState) Reset() {
+func (r *renderState) Reset() {
 	r.Instrument = nil
 	r.Period = nil
 	r.Volume = 1
@@ -34,20 +34,20 @@ func (r *RenderState) Reset() {
 	r.Pan = panning.CenterAhead
 }
 
-// ActiveState is the active state of a channel
-type ActiveState struct {
-	RenderState
+// activeState is the active state of a channel
+type activeState struct {
+	renderState
 	NoteControl intf.NoteControl
 }
 
 // Reset sets the active state to defaults
-func (a *ActiveState) Reset() {
-	a.RenderState.Reset()
+func (a *activeState) Reset() {
+	a.renderState.Reset()
 	a.NoteControl = nil
 }
 
 // Render renders an active channel's sample data for a the provided number of samples
-func (a *ActiveState) Render(globalVolume volume.Volume, mix *mixing.Mixer, panmixer mixing.PanMixer, samplerSpeed float32, samples int, duration time.Duration) (*mixing.Data, error) {
+func (a *activeState) Render(globalVolume volume.Volume, mix *mixing.Mixer, panmixer mixing.PanMixer, samplerSpeed float32, samples int, duration time.Duration) (*mixing.Data, error) {
 	if a.Period == nil {
 		return nil, nil
 	}

--- a/internal/player/state/activechannel.go
+++ b/internal/player/state/activechannel.go
@@ -1,0 +1,92 @@
+package state
+
+import (
+	"time"
+
+	"github.com/gotracker/gomixing/mixing"
+	"github.com/gotracker/gomixing/panning"
+	"github.com/gotracker/gomixing/sampling"
+	"github.com/gotracker/gomixing/volume"
+
+	"gotracker/internal/player/intf"
+	"gotracker/internal/player/note"
+)
+
+// RenderState is the information needed to make an instrument play
+type RenderState struct {
+	Instrument   intf.Instrument
+	Period       note.Period
+	Volume       volume.Volume
+	PeriodDelta  note.PeriodDelta
+	volumeActive bool
+	Pos          sampling.Pos
+	Pan          panning.Position
+}
+
+// Reset sets the render state to defaults
+func (r *RenderState) Reset() {
+	r.Instrument = nil
+	r.Period = nil
+	r.Volume = 1
+	r.PeriodDelta = 0
+	r.volumeActive = true
+	r.Pos = sampling.Pos{}
+	r.Pan = panning.CenterAhead
+}
+
+// ActiveState is the active state of a channel
+type ActiveState struct {
+	RenderState
+	NoteControl intf.NoteControl
+}
+
+// Reset sets the active state to defaults
+func (a *ActiveState) Reset() {
+	a.RenderState.Reset()
+	a.NoteControl = nil
+}
+
+// Render renders an active channel's sample data for a the provided number of samples
+func (a *ActiveState) Render(globalVolume volume.Volume, mix *mixing.Mixer, panmixer mixing.PanMixer, samplerSpeed float32, samples int, duration time.Duration) (*mixing.Data, error) {
+	if a.Period == nil {
+		return nil, nil
+	}
+
+	nc := a.NoteControl
+	if nc == nil {
+		return nil, nil
+	}
+	nc.SetVolume(a.Volume * globalVolume)
+	period := a.Period.Add(a.PeriodDelta)
+	nc.SetPeriod(period)
+
+	samplerAdd := float32(period.GetSamplerAdd(float64(samplerSpeed)))
+
+	nc.Update(duration)
+
+	panning := nc.GetCurrentPanning()
+	volMatrix := panmixer.GetMixingMatrix(panning)
+
+	// make a stand-alone data buffer for this channel for this tick
+	var data mixing.MixBuffer
+	if a.volumeActive {
+		data = mix.NewMixBuffer(samples)
+		mixData := mixing.SampleMixIn{
+			Sample:    sampling.NewSampler(nc, a.Pos, samplerAdd),
+			StaticVol: volume.Volume(1.0),
+			VolMatrix: volMatrix,
+			MixPos:    0,
+			MixLen:    samples,
+		}
+		data.MixInSample(mixData)
+	}
+
+	a.Pos.Add(samplerAdd * float32(samples))
+
+	return &mixing.Data{
+		Data:       data,
+		Pan:        a.Pan,
+		Volume:     volume.Volume(1.0),
+		SamplesLen: samples,
+	}, nil
+}

--- a/internal/player/state/channel.go
+++ b/internal/player/state/channel.go
@@ -47,7 +47,7 @@ type ChannelState struct {
 }
 
 // Process processes a channel's row data
-func (cs *ChannelState) Process(row intf.Row, globalVol volume.Volume, sd intf.SongData) {
+func (cs *ChannelState) Process(row intf.Row, sd intf.SongData) {
 	cs.prevState = cs.activeState.RenderState
 	cs.targetState = cs.activeState.RenderState
 	cs.DoRetriggerNote = true

--- a/internal/player/state/channel.go
+++ b/internal/player/state/channel.go
@@ -18,9 +18,9 @@ type commandFunc func(int, *ChannelState, int, bool)
 type ChannelState struct {
 	intf.Channel
 
-	activeState ActiveState
-	targetState RenderState
-	prevState   RenderState
+	activeState activeState
+	targetState renderState
+	prevState   renderState
 
 	ActiveEffect intf.Effect
 
@@ -48,8 +48,8 @@ type ChannelState struct {
 
 // Process processes a channel's row data
 func (cs *ChannelState) Process(row intf.Row, sd intf.SongData) {
-	cs.prevState = cs.activeState.RenderState
-	cs.targetState = cs.activeState.RenderState
+	cs.prevState = cs.activeState.renderState
+	cs.targetState = cs.activeState.renderState
 	cs.DoRetriggerNote = true
 	cs.NotePlayTick = 0
 	cs.RetriggerCount = 0


### PR DESCRIPTION
- cleaned up the general channel layout somewhat
  - pulled parameters specific to playing an instrument into their own state
- fixed some strange s3m-specific tracker decisions
- simplified OPL2 configuration
