### PR TITLE
General fixups and effect support

### DIFF
--- a/gotracker.go
+++ b/gotracker.go
@@ -23,11 +23,12 @@ import (
 
 // flags
 var (
-	outputSettings device.Settings
-	startingOrder  int
-	startingRow    int
-	canLoop        bool
-	effectCoverage bool
+	outputSettings         device.Settings
+	startingOrder          int
+	startingRow            int
+	canLoop                bool
+	effectCoverage         bool
+	panicOnUnhandledEffect bool
 )
 
 func main() {
@@ -42,6 +43,7 @@ func main() {
 	flag.StringVar(&outputSettings.Name, "O", output.DefaultOutputDeviceName, "output device")
 	flag.StringVar(&outputSettings.Filepath, "f", "output.wav", "output filepath")
 	flag.BoolVar(&effectCoverage, "E", false, "gather and display effect coverage data")
+	flag.BoolVar(&panicOnUnhandledEffect, "P", false, "panic when an unhandled effect is encountered")
 
 	flag.Parse()
 
@@ -112,6 +114,9 @@ func main() {
 
 	if !canLoop {
 		disableFeatures = append(disableFeatures, feature.OrderLoop)
+	}
+	if panicOnUnhandledEffect {
+		disableFeatures = append(disableFeatures, feature.IgnoreUnknownEffect)
 	}
 	playback.DisableFeatures(disableFeatures)
 

--- a/internal/format/s3m/layout/instrument.go
+++ b/internal/format/s3m/layout/instrument.go
@@ -177,3 +177,10 @@ func (inst *Instrument) Update(nc intf.NoteControl, tickDuration time.Duration) 
 		ii.Update(nc, tickDuration)
 	}
 }
+
+// SetEnvelopePosition sets the envelope position for the instrument
+func (inst *Instrument) SetEnvelopePosition(nc intf.NoteControl, ticks int) {
+	if ii := inst.Inst; ii != nil {
+		ii.SetEnvelopePosition(nc, ticks)
+	}
+}

--- a/internal/format/s3m/playback/effect/unhandled.go
+++ b/internal/format/s3m/playback/effect/unhandled.go
@@ -8,14 +8,15 @@ import (
 
 // UnhandledCommand is an unhandled command
 type UnhandledCommand struct {
-	intf.Effect
 	Command uint8
 	Info    uint8
 }
 
 // PreStart triggers when the effect enters onto the channel state
 func (e UnhandledCommand) PreStart(cs intf.Channel, p intf.Playback) {
-	panic("unhandled command")
+	if !p.IgnoreUnknownEffect() {
+		panic("unhandled command")
+	}
 }
 
 func (e UnhandledCommand) String() string {

--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -196,6 +196,7 @@ func (m *Manager) IncreaseTempo(delta int) {
 
 // DisableFeatures disables specified features
 func (m *Manager) DisableFeatures(features []feature.Feature) {
+	m.Tracker.DisableFeatures(features)
 	for _, f := range features {
 		switch f {
 		case feature.OrderLoop:

--- a/internal/format/xm/layout/channel/memory.go
+++ b/internal/format/xm/layout/channel/memory.go
@@ -13,6 +13,7 @@ type Memory struct {
 	tremolo             uint8
 	tremor              uint8
 	volumeSlide         uint8
+	globalVolumeSlide   uint8
 	finePortaUp         uint8
 	finePortaDown       uint8
 	fineVolumeSlideUp   uint8
@@ -92,6 +93,11 @@ func (m *Memory) Tremor(input uint8) uint8 {
 // VolumeSlide gets or sets the most recent non-zero value (or input) for Volume Slide
 func (m *Memory) VolumeSlide(input uint8) uint8 {
 	return m.getEffectMemory(input, &m.volumeSlide)
+}
+
+// GlobalVolumeSlide gets or sets the most recent non-zero value (or input) for Global Volume Slide
+func (m *Memory) GlobalVolumeSlide(input uint8) uint8 {
+	return m.getEffectMemory(input, &m.globalVolumeSlide)
 }
 
 // FinePortaUp gets or sets the most recent non-zero value (or input) for Fine Portamento Up

--- a/internal/format/xm/playback/effect/effect_globalvolumeslide.go
+++ b/internal/format/xm/playback/effect/effect_globalvolumeslide.go
@@ -1,0 +1,40 @@
+package effect
+
+import (
+	"fmt"
+
+	"gotracker/internal/format/xm/layout/channel"
+	"gotracker/internal/player/intf"
+)
+
+// GlobalVolumeSlide defines a global volume slide effect
+type GlobalVolumeSlide uint8 // 'H'
+
+// Start triggers on the first tick, but before the Tick() function is called
+func (e GlobalVolumeSlide) Start(cs intf.Channel, p intf.Playback) {
+	cs.ResetRetriggerCount()
+}
+
+// Tick is called on every tick
+func (e GlobalVolumeSlide) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
+	mem := cs.GetMemory().(*channel.Memory)
+	xy := mem.GlobalVolumeSlide(uint8(e))
+	x := uint8(xy >> 4)
+	y := uint8(xy & 0x0F)
+
+	if currentTick == 0 {
+		return
+	}
+
+	if x == 0 {
+		// global vol slide down
+		doGlobalVolSlide(p, -float32(y), 1.0)
+	} else if y == 0 {
+		// global vol slide up
+		doGlobalVolSlide(p, float32(y), 1.0)
+	}
+}
+
+func (e GlobalVolumeSlide) String() string {
+	return fmt.Sprintf("H%0.2x", uint8(e))
+}

--- a/internal/format/xm/playback/effect/effect_setenvelopeposition.go
+++ b/internal/format/xm/playback/effect/effect_setenvelopeposition.go
@@ -1,0 +1,23 @@
+package effect
+
+import (
+	"fmt"
+
+	"gotracker/internal/player/intf"
+)
+
+// SetEnvelopePosition defines a set envelope position effect
+type SetEnvelopePosition uint8 // 'Lxx'
+
+// Start triggers on the first tick, but before the Tick() function is called
+func (e SetEnvelopePosition) Start(cs intf.Channel, p intf.Playback) {
+	cs.ResetRetriggerCount()
+
+	xx := uint8(e)
+
+	cs.SetEnvelopePosition(int(xx))
+}
+
+func (e SetEnvelopePosition) String() string {
+	return fmt.Sprintf("L%0.2x", uint8(e))
+}

--- a/internal/format/xm/playback/effect/effectfactory_standard.go
+++ b/internal/format/xm/playback/effect/effectfactory_standard.go
@@ -51,7 +51,8 @@ func standardEffectFactory(mi intf.Memory, cd *channel.Data) intf.Effect {
 	case 0x11: // Global volume slide
 		return GlobalVolumeSlide(cd.EffectParameter)
 
-	//case 0x15: // Set envelope position
+	case 0x15: // Set envelope position
+		return SetEnvelopePosition(cd.EffectParameter)
 
 	case 0x19: // Panning slide
 		return PanSlide(cd.EffectParameter)

--- a/internal/format/xm/playback/effect/effectfactory_standard.go
+++ b/internal/format/xm/playback/effect/effectfactory_standard.go
@@ -48,7 +48,8 @@ func standardEffectFactory(mi intf.Memory, cd *channel.Data) intf.Effect {
 		return SetTempo(cd.EffectParameter)
 	case 0x10: // Set global volume
 		return SetGlobalVolume(cd.EffectParameter)
-	//case 0x11: // Global volume slide
+	case 0x11: // Global volume slide
+		return GlobalVolumeSlide(cd.EffectParameter)
 
 	//case 0x15: // Set envelope position
 

--- a/internal/format/xm/playback/effect/effectfactory_volume.go
+++ b/internal/format/xm/playback/effect/effectfactory_volume.go
@@ -10,6 +10,7 @@ func volumeEffectFactory(mi intf.Memory, v uint8) intf.Effect {
 	case v >= 0x00 && v <= 0x0f: // nothing
 		return nil
 	case v >= 0x10 && v <= 0x5f: // volume set - handled elsewhere
+		// really should be v >= 0x10 && v <= 0x50
 		return nil
 	case v >= 0x60 && v <= 0x6f: // vol slide down
 		return VolumeSlide(v & 0x0f)

--- a/internal/format/xm/playback/effect/intf/intf.go
+++ b/internal/format/xm/playback/effect/intf/intf.go
@@ -9,4 +9,5 @@ type XM interface {
 	SetTempo(int)
 	DecreaseTempo(int)
 	IncreaseTempo(int)
+	SetEnvelopePosition(uint8)
 }

--- a/internal/format/xm/playback/effect/unhandled.go
+++ b/internal/format/xm/playback/effect/unhandled.go
@@ -8,14 +8,15 @@ import (
 
 // UnhandledCommand is an unhandled command
 type UnhandledCommand struct {
-	intf.Effect
 	Command uint8
 	Info    uint8
 }
 
 // PreStart triggers when the effect enters onto the channel state
 func (e UnhandledCommand) PreStart(cs intf.Channel, p intf.Playback) {
-	panic("unhandled command")
+	if !p.IgnoreUnknownEffect() {
+		panic("unhandled command")
+	}
 }
 
 func (e UnhandledCommand) String() string {
@@ -31,13 +32,14 @@ func (e UnhandledCommand) String() string {
 
 // UnhandledVolCommand is an unhandled volume command
 type UnhandledVolCommand struct {
-	intf.Effect
 	Vol uint8
 }
 
 // PreStart triggers when the effect enters onto the channel state
 func (e UnhandledVolCommand) PreStart(cs intf.Channel, p intf.Playback) {
-	panic("unhandled command")
+	if !p.IgnoreUnknownEffect() {
+		panic("unhandled command")
+	}
 }
 
 func (e UnhandledVolCommand) String() string {

--- a/internal/format/xm/playback/effect/util.go
+++ b/internal/format/xm/playback/effect/util.go
@@ -24,6 +24,23 @@ func doVolSlide(cs intf.Channel, delta float32, multiplier float32) {
 	cs.SetActiveVolume(nv)
 }
 
+func doGlobalVolSlide(p intf.Playback, delta float32, multiplier float32) {
+	gv := p.GetGlobalVolume()
+	v := util.VolumeToXm(gv)
+	if v >= 0x10 && v <= 0x50 {
+		vol := int16((float32(v-0x10) + delta) * multiplier)
+		if vol >= 0x40 {
+			vol = 0x40
+		}
+		if vol < 0x00 {
+			vol = 0x00
+		}
+		v = uint8(vol) + 0x10
+	}
+	ngv := util.VolumeFromXm(v)
+	p.SetGlobalVolume(ngv)
+}
+
 func doPortaByDeltaAmiga(cs intf.Channel, delta int) {
 	period := cs.GetPeriod()
 	if period == nil {

--- a/internal/format/xm/playback/playback.go
+++ b/internal/format/xm/playback/playback.go
@@ -173,6 +173,7 @@ func (m *Manager) IncreaseTempo(delta int) {
 
 // DisableFeatures disables specified features
 func (m *Manager) DisableFeatures(features []feature.Feature) {
+	m.Tracker.DisableFeatures(features)
 	for _, f := range features {
 		switch f {
 		case feature.OrderLoop:

--- a/internal/instrument/envelope.go
+++ b/internal/instrument/envelope.go
@@ -137,3 +137,19 @@ func (ed *envData) getEnv(pos int, env *InstEnv) (EnvPoint, int) {
 	cur := env.Values[pos]
 	return cur, pos
 }
+
+func (ed *envData) setEnvelopePosition(ticks int, pos *int, rem *int, env *InstEnv, update envUpdateFunc) {
+	*pos = 0
+	*rem = 0
+	for ticks > 0 {
+		ed.updateEnv(pos, rem, env, update)
+		if ticks >= *rem {
+			ticks -= *rem
+			*rem = 0
+		} else {
+			*rem -= ticks
+			ticks = 0
+		}
+	}
+	ed.updateEnv(pos, rem, env, update)
+}

--- a/internal/instrument/instrument.go
+++ b/internal/instrument/instrument.go
@@ -14,7 +14,7 @@ import (
 type DataIntf interface {
 	GetSample(intf.NoteControl, sampling.Pos) volume.Matrix
 	GetCurrentPanning(intf.NoteControl) panning.Position
-
+	SetEnvelopePosition(intf.NoteControl, int)
 	Initialize(intf.NoteControl) error
 	Attack(intf.NoteControl)
 	Release(intf.NoteControl)

--- a/internal/instrument/instrument_opl2.go
+++ b/internal/instrument/instrument_opl2.go
@@ -100,6 +100,10 @@ func (inst *OPL2) GetCurrentPanning(ioc intf.NoteControl) panning.Position {
 	return panning.CenterAhead
 }
 
+// SetEnvelopePosition sets the envelope position for the note-control
+func (inst *OPL2) SetEnvelopePosition(ioc intf.NoteControl, ticks int) {
+}
+
 // Initialize completes the setup of this instrument
 func (inst *OPL2) Initialize(ioc intf.NoteControl) error {
 	ym := ym3812{}

--- a/internal/instrument/instrument_pcm.go
+++ b/internal/instrument/instrument_pcm.go
@@ -76,6 +76,12 @@ func (inst *PCM) GetCurrentPanning(ioc intf.NoteControl) panning.Position {
 	return finalPan
 }
 
+// SetEnvelopePosition sets the envelope position for the note-control
+func (inst *PCM) SetEnvelopePosition(ioc intf.NoteControl, ticks int) {
+	ed := ioc.GetData().(*envData)
+	ed.setEnvelopePosition(ticks, &ed.volEnvPos, &ed.volEnvTicksRemaining, &inst.VolEnv, ed.updateVolEnv)
+}
+
 func (inst *PCM) getVolEnv(ed *envData, pos sampling.Pos) volume.Volume {
 	if !inst.VolEnv.Enabled {
 		return volume.Volume(1.0)

--- a/internal/instrument/instrument_pcm.go
+++ b/internal/instrument/instrument_pcm.go
@@ -80,6 +80,9 @@ func (inst *PCM) GetCurrentPanning(ioc intf.NoteControl) panning.Position {
 func (inst *PCM) SetEnvelopePosition(ioc intf.NoteControl, ticks int) {
 	ed := ioc.GetData().(*envData)
 	ed.setEnvelopePosition(ticks, &ed.volEnvPos, &ed.volEnvTicksRemaining, &inst.VolEnv, ed.updateVolEnv)
+	if inst.VolEnv.SustainEnabled {
+		ed.setEnvelopePosition(ticks, &ed.panEnvPos, &ed.panEnvTicksRemaining, &inst.PanEnv, ed.updatePanEnv)
+	}
 }
 
 func (inst *PCM) getVolEnv(ed *envData, pos sampling.Pos) volume.Volume {

--- a/internal/player/feature/feature.go
+++ b/internal/player/feature/feature.go
@@ -11,4 +11,7 @@ const (
 
 	// PlayerSleepInterval describes the player sleep interval feature
 	PlayerSleepInterval
+
+	// IgnoreUnknownEffect describes a bypass/ignore of unknown effects
+	IgnoreUnknownEffect
 )

--- a/internal/player/intf/channel.go
+++ b/internal/player/intf/channel.go
@@ -66,4 +66,5 @@ type Channel interface {
 	SetOutputChannelNum(int)
 	SetVolumeActive(bool)
 	SetGlobalVolume(volume.Volume)
+	SetEnvelopePosition(int)
 }

--- a/internal/player/intf/instrument.go
+++ b/internal/player/intf/instrument.go
@@ -34,4 +34,5 @@ type Instrument interface {
 	NoteCut(NoteControl)
 	GetKeyOn(NoteControl) bool
 	Update(NoteControl, time.Duration)
+	SetEnvelopePosition(NoteControl, int)
 }

--- a/internal/player/intf/notecontrol.go
+++ b/internal/player/intf/notecontrol.go
@@ -31,4 +31,5 @@ type NoteControl interface {
 	GetPlayback() Playback
 	SetData(interface{})
 	GetData() interface{}
+	SetEnvelopePosition(int)
 }

--- a/internal/player/intf/playback.go
+++ b/internal/player/intf/playback.go
@@ -28,6 +28,7 @@ type Playback interface {
 	CanOrderLoop() bool
 	BreakOrder()
 	SetOnEffect(func(Effect))
+	IgnoreUnknownEffect() bool
 
 	SetupSampler(int, int, int) error
 }

--- a/internal/player/state/channel.go
+++ b/internal/player/state/channel.go
@@ -352,3 +352,10 @@ func (cs *ChannelState) SetOutputChannelNum(outputChNum int) {
 func (cs *ChannelState) SetGlobalVolume(gv volume.Volume) {
 	cs.LastGlobalVolume = gv
 }
+
+// SetEnvelopePosition sets the envelope position for the active instrument
+func (cs *ChannelState) SetEnvelopePosition(ticks int) {
+	if nc := cs.GetNoteControl(); nc != nil {
+		nc.SetEnvelopePosition(ticks)
+	}
+}

--- a/internal/player/tracker.go
+++ b/internal/player/tracker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gotracker/gomixing/volume"
 	device "github.com/gotracker/gosound"
 
+	"gotracker/internal/player/feature"
 	"gotracker/internal/player/intf"
 	"gotracker/internal/player/render"
 	"gotracker/internal/player/sampler"
@@ -33,6 +34,8 @@ type Tracker struct {
 
 	globalVolume volume.Volume
 	mixerVolume  volume.Volume
+
+	panicOnUnknownEffect bool
 }
 
 // Update runs processing on the tracker, producing premixed sound data
@@ -171,4 +174,19 @@ func (t *Tracker) GetMixerVolume() volume.Volume {
 // SetMixerVolume sets the mixer volume to the specified `vol` value
 func (t *Tracker) SetMixerVolume(vol volume.Volume) {
 	t.mixerVolume = vol
+}
+
+// IgnoreUnknownEffect returns true if the tracker wants unknown effects to be ignored
+func (t *Tracker) IgnoreUnknownEffect() bool {
+	return !t.panicOnUnknownEffect
+}
+
+// DisableFeatures disables specified features
+func (t *Tracker) DisableFeatures(features []feature.Feature) {
+	for _, f := range features {
+		switch f {
+		case feature.IgnoreUnknownEffect:
+			t.panicOnUnknownEffect = true
+		}
+	}
 }


### PR DESCRIPTION
- added commandline parameter for enabling panic when an unhandled track effect is encountered.
- added XM global volume slide support
- added XM set envelope position support
- basic cleanup of interfaces on some effects