### PR TITLE
Fix note-control release on retrigger

### DIFF
--- a/internal/format/s3m/playback/playback_command.go
+++ b/internal/format/s3m/playback/playback_command.go
@@ -49,6 +49,9 @@ func (m *Manager) processCommand(ch int, cs *state.ChannelState, currentTick int
 			cs.SetInstrument(nil)
 		}
 		if cs.UseTargetPeriod {
+			if nc := cs.GetNoteControl(); nc != nil {
+				nc.Release()
+			}
 			cs.SetPeriod(targetPeriod)
 			cs.PortaTargetPeriod = targetPeriod
 		}

--- a/internal/format/xm/playback/playback_command.go
+++ b/internal/format/xm/playback/playback_command.go
@@ -51,6 +51,9 @@ func (m *Manager) processEffect(ch int, cs *state.ChannelState, currentTick int,
 			cs.SetInstrument(nil)
 		}
 		if cs.UseTargetPeriod {
+			if nc := cs.GetNoteControl(); nc != nil {
+				nc.Release()
+			}
 			cs.SetPeriod(targetPeriod)
 			cs.PortaTargetPeriod = targetPeriod
 		}


### PR DESCRIPTION
- it was not triggering OPL2 notes as expected (they were getting stuck in sustain mode)