### PR TITLE
Fix up spaceship operator and period comparisons

### DIFF
--- a/internal/format/s3m/playback/effect/effect_portatonote.go
+++ b/internal/format/s3m/playback/effect/effect_portatonote.go
@@ -34,7 +34,7 @@ func (e PortaToNote) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	period = period.Add(cs.GetPeriodDelta())
 	ptp := cs.GetPortaTargetPeriod()
 	if currentTick != 0 {
-		if note.ComparePeriods(period, ptp) == 1 {
+		if note.ComparePeriods(period, ptp) == note.CompareRightHigher {
 			doPortaUpToNote(cs, float32(xx), 4, ptp) // subtracts
 		} else {
 			doPortaDownToNote(cs, float32(xx), 4, ptp) // adds

--- a/internal/format/s3m/playback/effect/util.go
+++ b/internal/format/s3m/playback/effect/util.go
@@ -46,7 +46,7 @@ func doPortaUpToNote(cs intf.Channel, amount float32, multiplier float32, target
 	delta := int(amount * multiplier)
 	d := note.PeriodDelta(-delta)
 	period = period.Add(d)
-	if note.ComparePeriods(period, target) == -1 {
+	if note.ComparePeriods(period, target) == note.CompareLeftHigher {
 		period = target
 	}
 	cs.SetPeriod(period)
@@ -73,7 +73,7 @@ func doPortaDownToNote(cs intf.Channel, amount float32, multiplier float32, targ
 	delta := int(amount * multiplier)
 	d := note.PeriodDelta(delta)
 	period = period.Add(d)
-	if note.ComparePeriods(period, target) == 1 {
+	if note.ComparePeriods(period, target) == note.CompareRightHigher {
 		period = target
 	}
 	cs.SetPeriod(period)

--- a/internal/format/s3m/playback/util/period.go
+++ b/internal/format/s3m/playback/util/period.go
@@ -32,17 +32,17 @@ func (p *AmigaPeriod) Add(delta note.PeriodDelta) note.Period {
 //  -1 if the current period is higher frequency than the `rhs` period
 //  0 if the current period is equal in frequency to the `rhs` period
 //  1 if the current period is lower frequency than the `rhs` period
-func (p *AmigaPeriod) Compare(rhs note.Period) int {
+func (p *AmigaPeriod) Compare(rhs note.Period) note.SpaceshipResult {
 	lf := p.GetFrequency()
 	rf := rhs.GetFrequency()
 
 	switch {
 	case lf > rf:
-		return -1
+		return note.CompareLeftHigher
 	case lf < rf:
-		return 1
+		return note.CompareRightHigher
 	default:
-		return 0
+		return note.CompareEqual
 	}
 }
 

--- a/internal/format/xm/playback/effect/effect_portatonote.go
+++ b/internal/format/xm/playback/effect/effect_portatonote.go
@@ -29,7 +29,7 @@ func (e PortaToNote) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	period := cs.GetPeriod()
 	ptp := cs.GetPortaTargetPeriod()
 	if currentTick != 0 {
-		if note.ComparePeriods(period, ptp) == 1 {
+		if note.ComparePeriods(period, ptp) == note.CompareRightHigher {
 			doPortaUpToNote(cs, float32(xx), 4, ptp, mem.LinearFreqSlides) // subtracts
 		} else {
 			doPortaDownToNote(cs, float32(xx), 4, ptp, mem.LinearFreqSlides) // adds

--- a/internal/format/xm/playback/effect/util.go
+++ b/internal/format/xm/playback/effect/util.go
@@ -75,7 +75,7 @@ func doPortaUp(cs intf.Channel, amount float32, multiplier float32, linearFreqSl
 
 func doPortaUpToNote(cs intf.Channel, amount float32, multiplier float32, target note.Period, linearFreqSlides bool) {
 	doPortaUp(cs, amount, multiplier, linearFreqSlides)
-	if period := cs.GetPeriod(); note.ComparePeriods(period, target) == -1 {
+	if period := cs.GetPeriod(); note.ComparePeriods(period, target) == note.CompareLeftHigher {
 		cs.SetPeriod(target)
 	}
 }
@@ -91,7 +91,7 @@ func doPortaDown(cs intf.Channel, amount float32, multiplier float32, linearFreq
 
 func doPortaDownToNote(cs intf.Channel, amount float32, multiplier float32, target note.Period, linearFreqSlides bool) {
 	doPortaDown(cs, amount, multiplier, linearFreqSlides)
-	if period := cs.GetPeriod(); note.ComparePeriods(period, target) == 1 {
+	if period := cs.GetPeriod(); note.ComparePeriods(period, target) == note.CompareRightHigher {
 		cs.SetPeriod(target)
 	}
 }

--- a/internal/format/xm/playback/util/period_amiga.go
+++ b/internal/format/xm/playback/util/period_amiga.go
@@ -24,17 +24,17 @@ func (p *AmigaPeriod) Add(delta note.PeriodDelta) note.Period {
 //  -1 if the current period is higher frequency than the `rhs` period
 //  0 if the current period is equal in frequency to the `rhs` period
 //  1 if the current period is lower frequency than the `rhs` period
-func (p *AmigaPeriod) Compare(rhs note.Period) int {
+func (p *AmigaPeriod) Compare(rhs note.Period) note.SpaceshipResult {
 	lf := p.GetFrequency()
 	rf := rhs.GetFrequency()
 
 	switch {
-	case lf > rf:
-		return -1
 	case lf < rf:
-		return 1
+		return note.CompareRightHigher
+	case lf > rf:
+		return note.CompareLeftHigher
 	default:
-		return 0
+		return note.CompareEqual
 	}
 }
 

--- a/internal/format/xm/playback/util/period_linear.go
+++ b/internal/format/xm/playback/util/period_linear.go
@@ -27,17 +27,17 @@ func (p *LinearPeriod) Add(delta note.PeriodDelta) note.Period {
 //  -1 if the current period is higher frequency than the `rhs` period
 //  0 if the current period is equal in frequency to the `rhs` period
 //  1 if the current period is lower frequency than the `rhs` period
-func (p *LinearPeriod) Compare(rhs note.Period) int {
+func (p *LinearPeriod) Compare(rhs note.Period) note.SpaceshipResult {
 	lf := p.GetFrequency()
 	rf := rhs.GetFrequency()
 
 	switch {
-	case lf > rf:
-		return -1
 	case lf < rf:
-		return 1
+		return note.CompareRightHigher
+	case lf > rf:
+		return note.CompareLeftHigher
 	default:
-		return 0
+		return note.CompareEqual
 	}
 }
 

--- a/internal/player/note/note.go
+++ b/internal/player/note/note.go
@@ -2,10 +2,26 @@ package note
 
 import "fmt"
 
+// SpaceshipResult is a comparison result for a three-way comparison (<=>)
+type SpaceshipResult int
+
+func (sr SpaceshipResult) String() string {
+	return fmt.Sprintf("%d", int(sr))
+}
+
+const (
+	// CompareRightHigher is returned when the right-hand side of a spaceship operator (<=>) is higher than the left-hand side
+	CompareRightHigher = SpaceshipResult(-1)
+	// CompareEqual is returned when the right-hand side of a spaceship operator (<=>) is equal to the left-hand side
+	CompareEqual = SpaceshipResult(0)
+	// CompareLeftHigher is returned when the left-hand side of a spaceship operator (<=>) is higher than the right-hand side
+	CompareLeftHigher = SpaceshipResult(1)
+)
+
 // Period is an interface that defines a sampler period
 type Period interface {
 	Add(PeriodDelta) Period
-	Compare(Period) int // <=>
+	Compare(Period) SpaceshipResult // <=>
 	Lerp(float64, Period) Period
 	GetSamplerAdd(float64) float64
 	GetFrequency() float64
@@ -17,14 +33,14 @@ type Period interface {
 type PeriodDelta float64
 
 // ComparePeriods compares two periods, taking nil into account
-func ComparePeriods(lhs Period, rhs Period) int {
+func ComparePeriods(lhs Period, rhs Period) SpaceshipResult {
 	if lhs == nil {
 		if rhs == nil {
-			return 0
+			return CompareEqual
 		}
-		return 1
+		return CompareRightHigher
 	} else if rhs == nil {
-		return -1
+		return CompareLeftHigher
 	}
 
 	return lhs.Compare(rhs)

--- a/internal/player/note/note_test.go
+++ b/internal/player/note/note_test.go
@@ -1,0 +1,97 @@
+package note_test
+
+import (
+	"fmt"
+	"testing"
+
+	"gotracker/internal/player/note"
+)
+
+// testPeriod defines a sampler period that follows the Amiga-style approach of note
+// definition. Useful in calculating resampling.
+type testPeriod float32
+
+// AddInteger truncates the current period to an integer and adds the delta integer in
+// then returns the resulting period
+func (p *testPeriod) AddInteger(delta int) testPeriod {
+	period := testPeriod(int(*p) + delta)
+	return period
+}
+
+// Add adds the current period to a delta value then returns the resulting period
+func (p *testPeriod) Add(delta note.PeriodDelta) note.Period {
+	period := *p
+	period += testPeriod(delta)
+	return &period
+}
+
+// Compare returns:
+//  -1 if the current period is higher frequency than the `rhs` period
+//  0 if the current period is equal in frequency to the `rhs` period
+//  1 if the current period is lower frequency than the `rhs` period
+func (p *testPeriod) Compare(rhs note.Period) note.SpaceshipResult {
+	lf := p.GetFrequency()
+	rf := rhs.GetFrequency()
+
+	switch {
+	case lf < rf:
+		return note.CompareRightHigher
+	case lf > rf:
+		return note.CompareLeftHigher
+	default:
+		return note.CompareEqual
+	}
+}
+
+// Lerp linear-interpolates the current period with the `rhs` period
+func (p *testPeriod) Lerp(t float64, rhs note.Period) note.Period {
+	right := testPeriod(0)
+	if r, ok := rhs.(*testPeriod); ok {
+		right = *r
+	}
+
+	period := *p
+	delta := note.PeriodDelta(t * (float64(right) - float64(period)))
+	period.Add(delta)
+	return &period
+}
+
+// GetSamplerAdd returns the number of samples to advance an instrument by given the period
+func (p *testPeriod) GetSamplerAdd(samplerSpeed float64) float64 {
+	period := float64(*p)
+	if period == 0 {
+		return 0
+	}
+	return samplerSpeed / period
+}
+
+// GetFrequency returns the frequency defined by the period
+func (p *testPeriod) GetFrequency() float64 {
+	return p.GetSamplerAdd(float64(8363 * 1712))
+}
+
+func (p *testPeriod) String() string {
+	return fmt.Sprintf("%f", *p)
+}
+
+func periodCompareTest(t *testing.T, lhs note.Period, rhs note.Period, expected note.SpaceshipResult) {
+	t.Helper()
+
+	if note.ComparePeriods(lhs, rhs) != expected {
+		t.Fatalf("%v <=> %v was not %v", lhs, rhs, expected)
+	}
+}
+
+func TestPeriodCompare(t *testing.T) {
+	lhs1 := testPeriod(1)
+	rhs1 := testPeriod(1)
+	periodCompareTest(t, &lhs1, &rhs1, note.CompareEqual)
+
+	lhs2 := testPeriod(1)
+	rhs2 := testPeriod(2)
+	periodCompareTest(t, &lhs2, &rhs2, note.CompareLeftHigher)
+
+	lhs3 := testPeriod(2)
+	rhs3 := testPeriod(1)
+	periodCompareTest(t, &lhs3, &rhs3, note.CompareRightHigher)
+}


### PR DESCRIPTION
- things were not happy in spaceship operator land.
- made things more consistent by adding in constants for comparison results.
- also added a test to ensure proper comparison expectations.