### PR TITLE
IT effect and various playback fixes, part 2

### DIFF
--- a/gotracker.go
+++ b/gotracker.go
@@ -12,6 +12,7 @@ import (
 	device "github.com/gotracker/gosound"
 
 	"gotracker/internal/format"
+	itEffect "gotracker/internal/format/it/playback/effect"
 	s3mEffect "gotracker/internal/format/s3m/playback/effect"
 	xmEffect "gotracker/internal/format/xm/playback/effect"
 	"gotracker/internal/output"
@@ -127,6 +128,12 @@ func main() {
 			var name string
 			switch t := e.(type) {
 			case *xmEffect.VolEff:
+				for _, eff := range t.Effects {
+					typ := reflect.TypeOf(eff)
+					name = typ.Name()
+					effectMap[name]++
+				}
+			case *itEffect.VolEff:
 				for _, eff := range t.Effects {
 					typ := reflect.TypeOf(eff)
 					name = typ.Name()

--- a/internal/format/it/layout/channel/memory.go
+++ b/internal/format/it/layout/channel/memory.go
@@ -56,8 +56,9 @@ func (m *Memory) getEffectMemory(input uint8, reg *uint8) uint8 {
 }
 
 // VolumeSlide gets or sets the most recent non-zero value (or input) for Volume Slide
-func (m *Memory) VolumeSlide(input uint8) uint8 {
-	return m.getEffectMemory(input, &m.volumeSlide)
+func (m *Memory) VolumeSlide(input uint8) (uint8, uint8) {
+	xy := m.getEffectMemory(input, &m.volumeSlide)
+	return xy >> 4, xy & 0x0f
 }
 
 // PortaDown gets or sets the most recent non-zero value (or input) for Portamento Down

--- a/internal/format/it/load/itformat.go
+++ b/internal/format/it/load/itformat.go
@@ -168,10 +168,11 @@ func convertItFileToSong(f *itfile.File) (*layout.Song, error) {
 	channels := make([]layout.ChannelSetting, lastEnabledChannel+1)
 	for chNum := range channels {
 		cs := layout.ChannelSetting{
-			Enabled:        true,
-			InitialVolume:  volume.Volume(1),
-			ChannelVolume:  volume.Volume(f.Head.ChannelVol[chNum].Value()),
-			InitialPanning: util.PanningFromIt(f.Head.ChannelPan[chNum]),
+			OutputChannelNum: chNum,
+			Enabled:          true,
+			InitialVolume:    volume.Volume(1),
+			ChannelVolume:    volume.Volume(f.Head.ChannelVol[chNum].Value()),
+			InitialPanning:   util.PanningFromIt(f.Head.ChannelPan[chNum]),
 			Memory: channel.Memory{
 				LinearFreqSlides: linearFrequencySlides,
 				OldEffectMode:    oldEffectMode,

--- a/internal/format/it/load/itformat.go
+++ b/internal/format/it/load/itformat.go
@@ -27,7 +27,12 @@ func moduleHeaderToHeader(fh *itfile.ModuleHeader) (*layout.Header, error) {
 		InitialSpeed: int(fh.InitialSpeed),
 		InitialTempo: int(fh.InitialTempo),
 		GlobalVolume: volume.Volume(fh.GlobalVolume.Value()),
-		MixingVolume: volume.Volume(fh.MixingVolume.Value()),
+	}
+	switch {
+	case fh.TrackerCompatVersion < 0x200:
+		head.MixingVolume = volume.Volume(fh.MixingVolume.Value())
+	case fh.TrackerCompatVersion >= 0x200:
+		head.MixingVolume = volume.Volume(fh.MixingVolume) / 255
 	}
 	return &head, nil
 }

--- a/internal/format/it/playback/effect/effect_finevolslidedown.go
+++ b/internal/format/it/playback/effect/effect_finevolslidedown.go
@@ -18,7 +18,7 @@ func (e FineVolumeSlideDown) Start(cs intf.Channel, p intf.Playback) {
 // Tick is called on every tick
 func (e FineVolumeSlideDown) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
-	y := mem.VolumeSlide(uint8(e)) & 0x0F
+	_, y := mem.VolumeSlide(uint8(e))
 
 	if y != 0x0F && currentTick == 0 {
 		doVolSlide(cs, -float32(y), 1.0)

--- a/internal/format/it/playback/effect/effect_finevolslideup.go
+++ b/internal/format/it/playback/effect/effect_finevolslideup.go
@@ -18,7 +18,7 @@ func (e FineVolumeSlideUp) Start(cs intf.Channel, p intf.Playback) {
 // Tick is called on every tick
 func (e FineVolumeSlideUp) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
-	x := mem.VolumeSlide(uint8(e)) >> 4
+	x, _ := mem.VolumeSlide(uint8(e))
 
 	if x != 0x0F && currentTick == 0 {
 		doVolSlide(cs, float32(x), 1.0)

--- a/internal/format/it/playback/effect/effect_volslidedown.go
+++ b/internal/format/it/playback/effect/effect_volslidedown.go
@@ -18,7 +18,7 @@ func (e VolumeSlideDown) Start(cs intf.Channel, p intf.Playback) {
 // Tick is called on every tick
 func (e VolumeSlideDown) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
-	y := mem.VolumeSlide(uint8(e)) & 0x0F
+	_, y := mem.VolumeSlide(uint8(e))
 
 	doVolSlide(cs, -float32(y), 1.0)
 }

--- a/internal/format/it/playback/effect/effect_volslideup.go
+++ b/internal/format/it/playback/effect/effect_volslideup.go
@@ -18,7 +18,7 @@ func (e VolumeSlideUp) Start(cs intf.Channel, p intf.Playback) {
 // Tick is called on every tick
 func (e VolumeSlideUp) Tick(cs intf.Channel, p intf.Playback, currentTick int) {
 	mem := cs.GetMemory().(*channel.Memory)
-	x := mem.VolumeSlide(uint8(e)) >> 4
+	x, _ := mem.VolumeSlide(uint8(e))
 
 	doVolSlide(cs, float32(x), 1.0)
 }

--- a/internal/format/it/playback/effect/effectfactory.go
+++ b/internal/format/it/playback/effect/effectfactory.go
@@ -192,18 +192,16 @@ func specialNoteEffects(cd *channel.Data) intf.Effect {
 }
 
 func volumeSlideFactory(mem *channel.Memory, cd uint8, ce uint8) intf.Effect {
-	xy := mem.VolumeSlide(uint8(ce))
-	x := uint8(xy >> 4)
-	y := uint8(xy & 0x0F)
+	x, y := mem.VolumeSlide(uint8(ce))
 	switch {
 	case x == 0:
-		return VolumeSlideDown(xy)
+		return VolumeSlideDown(ce)
 	case y == 0:
-		return VolumeSlideUp(xy)
+		return VolumeSlideUp(ce)
 	case x == 0x0f:
-		return FineVolumeSlideDown(xy)
+		return FineVolumeSlideDown(ce)
 	case y == 0x0f:
-		return FineVolumeSlideUp(xy)
+		return FineVolumeSlideUp(ce)
 	}
 	// There is a chance that a volume slide command is set with an invalid
 	// value or is 00, in which case the memory might have the invalid value,

--- a/internal/format/it/playback/util/util.go
+++ b/internal/format/it/playback/util/util.go
@@ -145,7 +145,7 @@ func FrequencyFromSemitone(semitone note.Semitone, c2spd note.C2SPD, linearFreqS
 
 // ToAmigaPeriod calculates an amiga period for a linear finetune period
 func ToAmigaPeriod(finetunes note.Finetune, c2spd note.C2SPD) AmigaPeriod {
-	linFreq := float64(c2spd) * math.Pow(2, float64(finetunes)/768) / (DefaultC2Spd * 2)
+	linFreq := float64(c2spd) * math.Pow(2, float64(finetunes)/768) / (DefaultC2Spd * 4)
 
 	period := AmigaPeriod(float64(semitonePeriodTable[0]) / linFreq)
 	return period
@@ -157,7 +157,7 @@ func ToLinearPeriod(p note.Period) *LinearPeriod {
 	case *LinearPeriod:
 		return pp
 	case *AmigaPeriod:
-		linFreq := float64(semitonePeriodTable[0]) * 2 / float64(*pp)
+		linFreq := float64(semitonePeriodTable[0]) * 4 / float64(*pp)
 
 		fts := note.Finetune(768 * math.Log2(linFreq))
 

--- a/internal/format/it/playback/util/util.go
+++ b/internal/format/it/playback/util/util.go
@@ -46,7 +46,9 @@ func CalcSemitonePeriod(semi note.Semitone, ft note.Finetune, c2spd note.C2SPD, 
 	if linearFreqSlides {
 		nft := int(semi)*64 + int(ft)
 		return &LinearPeriod{
-			Finetune: note.Finetune(nft),
+			// NOTE: not sure why the magic downshift a whole octave,
+			// but it makes all the calculations work, so here we are.
+			Finetune: note.Finetune(nft) - 768,
 			C2Spd:    c2spd,
 		}
 	}
@@ -145,7 +147,8 @@ func FrequencyFromSemitone(semitone note.Semitone, c2spd note.C2SPD, linearFreqS
 
 // ToAmigaPeriod calculates an amiga period for a linear finetune period
 func ToAmigaPeriod(finetunes note.Finetune, c2spd note.C2SPD) AmigaPeriod {
-	linFreq := float64(c2spd) * math.Pow(2, float64(finetunes)/768) / (DefaultC2Spd * 4)
+	pow := math.Pow(2, float64(finetunes)/768)
+	linFreq := float64(c2spd) * pow / float64(DefaultC2Spd)
 
 	period := AmigaPeriod(float64(semitonePeriodTable[0]) / linFreq)
 	return period
@@ -157,7 +160,7 @@ func ToLinearPeriod(p note.Period) *LinearPeriod {
 	case *LinearPeriod:
 		return pp
 	case *AmigaPeriod:
-		linFreq := float64(semitonePeriodTable[0]) * 4 / float64(*pp)
+		linFreq := float64(semitonePeriodTable[0]) / float64(*pp)
 
 		fts := note.Finetune(768 * math.Log2(linFreq))
 

--- a/internal/instrument/instrument_pcm.go
+++ b/internal/instrument/instrument_pcm.go
@@ -58,7 +58,7 @@ func (inst *PCM) GetCurrentPeriodDelta(ioc intf.NoteControl) note.PeriodDelta {
 	}
 
 	ed := ioc.GetData().(*pcmState)
-	return ed.pitchEnvValue
+	return ed.pitchEnvState.Value.(note.PeriodDelta)
 }
 
 // GetCurrentPanning returns the panning envelope position
@@ -69,7 +69,7 @@ func (inst *PCM) GetCurrentPanning(ioc intf.NoteControl) panning.Position {
 	}
 
 	ed := ioc.GetData().(*pcmState)
-	y := ed.panEnvValue
+	y := ed.panEnvState.Value.(panning.Position)
 
 	// panning envelope value `y` modifies instrument panning value `x`
 	// such that `x` is primary component and `y` is secondary
@@ -101,9 +101,9 @@ func (inst *PCM) GetCurrentPanning(ioc intf.NoteControl) panning.Position {
 // SetEnvelopePosition sets the envelope position for the note-control
 func (inst *PCM) SetEnvelopePosition(ioc intf.NoteControl, ticks int) {
 	ed := ioc.GetData().(*pcmState)
-	ed.setEnvelopePosition(ticks, &ed.volEnvPos, &ed.volEnvTicksRemaining, &inst.VolEnv, ed.updateVolEnv)
+	ed.setEnvelopePosition(ticks, &ed.volEnvState, &inst.VolEnv, ed.updateVolEnv)
 	if inst.VolEnv.SustainEnabled {
-		ed.setEnvelopePosition(ticks, &ed.panEnvPos, &ed.panEnvTicksRemaining, &inst.PanEnv, ed.updatePanEnv)
+		ed.setEnvelopePosition(ticks, &ed.panEnvState, &inst.PanEnv, ed.updatePanEnv)
 	}
 }
 
@@ -113,7 +113,7 @@ func (inst *PCM) getVolEnv(ed *pcmState, pos sampling.Pos) volume.Volume {
 	}
 
 	fadeVol := ed.fadeoutVol
-	return fadeVol * ed.volEnvValue
+	return fadeVol * ed.volEnvState.Value.(volume.Volume)
 }
 
 func (inst *PCM) getSampleDry(pos sampling.Pos, keyOn bool) volume.Matrix {
@@ -158,19 +158,19 @@ func (inst *PCM) Attack(ioc intf.NoteControl) {
 	ed.prevKeyOn = ed.keyOn
 	ed.keyOn = true
 	if inst.VolEnv.Enabled {
-		ed.volEnvPos = 0
-		ed.volEnvTicksRemaining = 0
-		ed.updateEnv(&ed.volEnvPos, &ed.volEnvTicksRemaining, &inst.VolEnv, ed.updateVolEnv)
+		ed.volEnvState.Pos = 0
+		ed.volEnvState.TicksRemaining = 0
+		ed.updateEnv(&ed.volEnvState, &inst.VolEnv, ed.updateVolEnv)
 	}
 	if inst.PanEnv.Enabled {
-		ed.panEnvPos = 0
-		ed.panEnvTicksRemaining = 0
-		ed.updateEnv(&ed.panEnvPos, &ed.panEnvTicksRemaining, &inst.PanEnv, ed.updatePanEnv)
+		ed.panEnvState.Pos = 0
+		ed.panEnvState.TicksRemaining = 0
+		ed.updateEnv(&ed.panEnvState, &inst.PanEnv, ed.updatePanEnv)
 	}
 	if inst.PitchEnv.Enabled {
-		ed.pitchEnvPos = 0
-		ed.pitchEnvTicksRemaining = 0
-		ed.updateEnv(&ed.pitchEnvPos, &ed.pitchEnvTicksRemaining, &inst.PitchEnv, ed.updatePitchEnv)
+		ed.pitchEnvState.Pos = 0
+		ed.pitchEnvState.TicksRemaining = 0
+		ed.updateEnv(&ed.pitchEnvState, &inst.PitchEnv, ed.updatePitchEnv)
 	}
 }
 

--- a/internal/instrument/instrument_pcm.go
+++ b/internal/instrument/instrument_pcm.go
@@ -157,6 +157,7 @@ func (inst *PCM) Attack(ioc intf.NoteControl) {
 	ed.fadeoutVol = volume.Volume(1.0)
 	ed.prevKeyOn = ed.keyOn
 	ed.keyOn = true
+	ed.fadingOut = false
 	if inst.VolEnv.Enabled {
 		ed.volEnvState.Pos = 0
 		ed.volEnvState.TicksRemaining = 0

--- a/internal/instrument/loopmode.go
+++ b/internal/instrument/loopmode.go
@@ -86,8 +86,10 @@ func calcLoopedSamplePosMode1(pos int, length int, loopBegin int, loopEnd int) i
 	}
 
 	loopLen := loopEnd - loopBegin
-	if loopLen <= 0 {
+	if loopLen < 0 {
 		return length
+	} else if loopLen == 0 {
+		return loopBegin
 	}
 
 	loopedPos := (pos - length) % loopLen
@@ -106,11 +108,13 @@ func calcLoopedSamplePosMode2(pos int, length int, loopBegin int, loopEnd int) i
 	}
 
 	loopLen := loopEnd - loopBegin
-	if loopLen <= 0 {
+	if loopLen < 0 {
 		if pos < length {
 			return pos
 		}
 		return length
+	} else if loopLen == 0 {
+		return loopBegin
 	}
 
 	dist := pos - loopEnd
@@ -130,11 +134,13 @@ func calcLoopedSamplePosPingPong(pos int, length int, loopBegin int, loopEnd int
 	}
 
 	loopLen := loopEnd - loopBegin
-	if loopLen <= 0 {
+	if loopLen < 0 {
 		if pos < length {
 			return pos
 		}
 		return length
+	} else if loopLen == 0 {
+		return loopBegin
 	}
 
 	dist := pos - loopEnd


### PR DESCRIPTION
- simplified volume slide calculations
- cleaned up envelope calculations by moving state information to reusable objects
- cleaned up loop calculations in sampling and envelopes
- added support for extended mixing volume range found in >= 2.00 IT formats
  - undocumented feature from the format... awesome. 👎 
- added a missing effect coverage case (oops)
- fixed a missing magic value in the linear frequency calculations for IT format
  - shouldn't have to add this, but for some reason everything goes to hell if it isn't there.
- fixed the fadeout flag getting stuck on XM playback