### PR TITLE
Command Improvements, Update 4

### DIFF
--- a/internal/command/device_list.go
+++ b/internal/command/device_list.go
@@ -19,8 +19,10 @@ var (
 )
 
 func init() {
-	deviceListCmd.Flags().BoolVarP(&deviceListAddHeader, "add-header", "H", deviceListAddHeader, "add header row(s) for formats that support it")
-	deviceListCmd.Flags().StringVarP(&deviceListFormat, "format", "f", deviceListFormat, "format of output {human, csv, json}")
+	if flags := deviceListCmd.Flags(); flags != nil {
+		flags.BoolVarP(&deviceListAddHeader, "add-header", "H", deviceListAddHeader, "add header row(s) for formats that support it")
+		flags.StringVarP(&deviceListFormat, "format", "f", deviceListFormat, "format of output {human, csv, json}")
+	}
 
 	deviceCmd.AddCommand(deviceListCmd)
 }

--- a/internal/command/libraries.go
+++ b/internal/command/libraries.go
@@ -1,0 +1,20 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(librariesCmd)
+}
+
+var (
+	librariesCmd = &cobra.Command{
+		Use:   "libraries",
+		Short: "List information about embedded libraries",
+		Long:  `List information about embedded libraries.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		},
+	}
+)

--- a/internal/command/libraries_list.go
+++ b/internal/command/libraries_list.go
@@ -1,0 +1,172 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	libListFieldName     bool = true
+	libListFieldHomepage bool = true
+	libListFieldPackage  bool = false
+	libListFieldLicense  bool = true
+)
+
+type libraryInfo struct {
+	Name     string
+	Package  string
+	Homepage string
+	License  string
+}
+
+var librariesList = []libraryInfo{
+	{
+		Name:     "x/sys",
+		Package:  "golang.org/x/sys",
+		License:  "BSD-3-Clause",
+		Homepage: "",
+	},
+	{
+		Name:     "mousetrap",
+		Package:  "github.com/inconshreveable/mousetrap",
+		License:  "Apache-2.0",
+		Homepage: "https://github.com/inconshreveable/mousetrap",
+	},
+	{
+		Name:     "pflag",
+		Package:  "github.com/spf13/pflag",
+		License:  "BSD-3-Clause",
+		Homepage: "https://github.com/spf13/pflag",
+	},
+	{
+		Name:     "OPL2",
+		Package:  "github.com/gotracker/opl2",
+		License:  "GPL-2.0",
+		Homepage: "https://github.com/gotracker/opl2",
+	},
+	{
+		Name:     "gomixing",
+		Package:  "github.com/gotracker/gomixing",
+		License:  "Unlicense",
+		Homepage: "https://github.com/gotracker/gomixing",
+	},
+	{
+		Name:     "Terminal progress bar for Go",
+		Package:  "github.com/cheggaaa/pb",
+		License:  "BSD-3-Clause",
+		Homepage: "https://github.com/cheggaaa/pb",
+	},
+	{
+		Name:     "gosound",
+		Package:  "github.com/gotracker/gosound",
+		License:  "Unlicense",
+		Homepage: "https://github.com/gotracker/gosound",
+	},
+	{
+		Name:     "errors",
+		Package:  "github.com/pkg/errors",
+		License:  "BSD-2-Clause",
+		Homepage: "https://github.com/pkg/errors",
+	},
+	{
+		Name:     "goaudiofile",
+		Package:  "github.com/gotracker/goaudiofile",
+		License:  "Unlicense",
+		Homepage: "https://github.com/gotracker/goaudiofile",
+	},
+	{
+		Name:     "gotracker/voice",
+		Package:  "github.com/gotracker/voice",
+		License:  "Unlicense",
+		Homepage: "https://github.com/gotracker/voice",
+	},
+	{
+		Name:     "go-runewidth",
+		Package:  "github.com/mattn/go-runewidth",
+		License:  "MIT",
+		Homepage: "https://github.com/mattn/go-runewidth",
+	},
+	{
+		Name:     "go-winmm",
+		Package:  "github.com/heucuva/go-winmm",
+		License:  "Unlicense",
+		Homepage: "https://github.com/heucuva/go-winmm",
+	},
+	{
+		Name:     "Cobra",
+		Package:  "github.com/spf13/cobra",
+		License:  "Apache-2.0",
+		Homepage: "https://github.com/spf13/cobra",
+	},
+}
+
+func init() {
+	if flags := librariesListCmd.Flags(); flags != nil {
+		flags.BoolVarP(&libListFieldName, "name", "n", libListFieldName, "display library name")
+		flags.BoolVarP(&libListFieldHomepage, "homepage", "H", libListFieldHomepage, "display library homepage URL")
+		flags.BoolVarP(&libListFieldPackage, "package", "p", libListFieldPackage, "display library package")
+		flags.BoolVarP(&libListFieldLicense, "license", "l", libListFieldLicense, "display library license type")
+	}
+	librariesCmd.AddCommand(librariesListCmd)
+}
+
+var (
+	librariesListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List the libraries used in Gotracker",
+		Long:  `List the libraries used in Gotracker`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nameIdx := make(map[string]int)
+			var names []string
+
+			for idx, lib := range librariesList {
+				nameIdx[lib.Name] = idx
+				names = append(names, lib.Name)
+			}
+
+			sort.Strings(names)
+
+			var fields []string
+			if libListFieldName {
+				fields = append(fields, "Name")
+			}
+			if libListFieldPackage {
+				fields = append(fields, "Package")
+			}
+			if libListFieldHomepage {
+				fields = append(fields, "Homepage")
+			}
+			if libListFieldLicense {
+				fields = append(fields, "License")
+			}
+
+			if len(fields) == 0 {
+				return nil
+			}
+
+			tw := tabwriter.NewWriter(os.Stdout, 0, 8, 0, '\t', 0)
+			fmt.Fprintln(tw, strings.Join(fields, "\t"))
+			for _, name := range names {
+				idx := nameIdx[name]
+				lib := librariesList[idx]
+				v := reflect.ValueOf(lib)
+
+				for i, field := range fields {
+					if i != 0 {
+						fmt.Fprint(tw, "\t")
+					}
+					vf := v.FieldByName(field)
+					fmt.Fprint(tw, vf.Interface())
+				}
+				fmt.Fprintln(tw)
+			}
+			return tw.Flush()
+		},
+	}
+)

--- a/internal/command/play_secondreality.go
+++ b/internal/command/play_secondreality.go
@@ -11,8 +11,10 @@ var (
 )
 
 func init() {
-	secondRealityCmd.Flags().StringVar(&pmPath, "pm", pmPath, "path to 2nd_pm.s3m")
-	secondRealityCmd.Flags().StringVar(&skavPath, "skav", skavPath, "path to 2nd_skav.s3m")
+	if flags := secondRealityCmd.Flags(); flags != nil {
+		flags.StringVar(&pmPath, "pm", pmPath, "path to 2nd_pm.s3m")
+		flags.StringVar(&skavPath, "skav", skavPath, "path to 2nd_skav.s3m")
+	}
 
 	playCmd.AddCommand(secondRealityCmd)
 }
@@ -46,8 +48,8 @@ var secondRealityCmd = &cobra.Command{
 					row:   -1,
 				},
 				end: orderDetails{
-					order: -1,
-					row:   -1,
+					order: 83,
+					row:   56,
 				},
 			},
 			{
@@ -60,10 +62,11 @@ var secondRealityCmd = &cobra.Command{
 					order: -1,
 					row:   -1,
 				},
+				loopEnabled: loopSong,
 			},
 		}
 
-		playedAtLeastOne, err := playSongs(songs)
+		playedAtLeastOne, err := playSongs(songs, loopPlaylist)
 		if err != nil {
 			return err
 		}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -12,7 +12,8 @@ import (
 
 // flags
 var (
-	profiler bool
+	profiler            bool   = false
+	profilerBindAddress string = "localhost:6060"
 )
 
 var rootCmd = &cobra.Command{
@@ -22,7 +23,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if profiler {
 			go func() {
-				log.Println(http.ListenAndServe("localhost:6060", nil))
+				log.Println(http.ListenAndServe(profilerBindAddress, nil))
 			}()
 		}
 		return nil
@@ -47,5 +48,8 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&profiler, "profiler", "p", false, "enable profiler (and supporting http server)")
+	if persistFlags := rootCmd.PersistentFlags(); persistFlags != nil {
+		persistFlags.BoolVar(&profiler, "profiler", profiler, "enable profiler (and supporting http server)")
+		persistFlags.StringVar(&profilerBindAddress, "profiler-bind-addr", profilerBindAddress, "profiler bind address (if enabled)")
+	}
 }


### PR DESCRIPTION
## Added
- Silent (text) mode has been added to `play` (and its sub-function(s)) so that non-error text will not be displayed
  - useful for background music playing
- `libraries list` has been added so users may view the libraries used by the application and the library license information.
- Added a profiler bind address override flag.
- Added a playlist loop flag (`--loop-playlist`).

## Fixed and Changed
- Cleaned up the end of `2nd_pm.s3m` playback within the `play second-reality` function
  - it was playing dead air for far too long
- Renamed the song loop flag to `--loop-song`

## Removed
- Removed the short flag for the profiler activation.

## Notes
- Currently, there is no redistribution of the license files for the libraries. Future executable builds may include these, but for now, a link to the homepages for the libs is probably sufficient.