### PR TITLE
Clean up format managers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gotracker
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -13,4 +13,21 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/heucuva/go-directsound v1.0.0 // indirect
+	github.com/heucuva/go-win32 v1.0.0 // indirect
+	github.com/heucuva/go-winmm v1.0.0 // indirect
+	github.com/icza/bitio v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jfreymuth/pulse v0.1.0 // indirect
+	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/mewkiz/flac v1.0.6 // indirect
+	github.com/mewkiz/pkg v0.0.0-20190919212034-518ade7978e2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 // indirect
 )

--- a/internal/format/it/it.go
+++ b/internal/format/it/it.go
@@ -7,9 +7,7 @@ import (
 	"gotracker/internal/player/intf"
 )
 
-type format struct {
-	intf.Format
-}
+type format struct{}
 
 var (
 	// IT is the exported interface to the IT file loader

--- a/internal/format/it/playback/playback.go
+++ b/internal/format/it/playback/playback.go
@@ -4,7 +4,6 @@ import (
 	device "github.com/gotracker/gosound"
 
 	"gotracker/internal/format/it/layout"
-	effectIntf "gotracker/internal/format/it/playback/effect/intf"
 	"gotracker/internal/format/it/playback/state/pattern"
 	"gotracker/internal/format/it/playback/util"
 	"gotracker/internal/player"
@@ -20,7 +19,6 @@ import (
 // Manager is a playback manager for IT music
 type Manager struct {
 	player.Tracker
-	effectIntf.IT
 
 	song *layout.Song
 
@@ -265,4 +263,7 @@ func (m *Manager) GetName() string {
 // SetOnEffect sets the callback for an effect being generated for a channel
 func (m *Manager) SetOnEffect(fn func(intf.Effect)) {
 	m.OnEffect = fn
+}
+
+func (m *Manager) SetEnvelopePosition(v uint8) {
 }

--- a/internal/format/mod/mod.go
+++ b/internal/format/mod/mod.go
@@ -6,9 +6,7 @@ import (
 	"gotracker/internal/player/intf"
 )
 
-type format struct {
-	intf.Format
-}
+type format struct{}
 
 var (
 	// MOD is the exported interface to the MOD file loader

--- a/internal/format/s3m/playback/playback.go
+++ b/internal/format/s3m/playback/playback.go
@@ -6,7 +6,6 @@ import (
 	device "github.com/gotracker/gosound"
 
 	"gotracker/internal/format/s3m/layout"
-	effectIntf "gotracker/internal/format/s3m/playback/effect/intf"
 	"gotracker/internal/format/s3m/playback/state/pattern"
 	"gotracker/internal/format/s3m/playback/util"
 	"gotracker/internal/player"
@@ -22,7 +21,6 @@ import (
 // Manager is a playback manager for S3M music
 type Manager struct {
 	player.Tracker
-	effectIntf.S3M
 
 	song *layout.Song
 

--- a/internal/format/s3m/s3m.go
+++ b/internal/format/s3m/s3m.go
@@ -7,9 +7,7 @@ import (
 	"gotracker/internal/player/intf"
 )
 
-type format struct {
-	intf.Format
-}
+type format struct{}
 
 var (
 	// S3M is the exported interface to the S3M file loader

--- a/internal/format/xm/playback/playback.go
+++ b/internal/format/xm/playback/playback.go
@@ -4,7 +4,6 @@ import (
 	device "github.com/gotracker/gosound"
 
 	"gotracker/internal/format/xm/layout"
-	effectIntf "gotracker/internal/format/xm/playback/effect/intf"
 	"gotracker/internal/format/xm/playback/state/pattern"
 	"gotracker/internal/format/xm/playback/util"
 	"gotracker/internal/player"
@@ -20,7 +19,6 @@ import (
 // Manager is a playback manager for XM music
 type Manager struct {
 	player.Tracker
-	effectIntf.XM
 
 	song *layout.Song
 
@@ -261,4 +259,7 @@ func (m *Manager) GetName() string {
 // SetOnEffect sets the callback for an effect being generated for a channel
 func (m *Manager) SetOnEffect(fn func(intf.Effect)) {
 	m.OnEffect = fn
+}
+
+func (m *Manager) SetEnvelopePosition(v uint8) {
 }

--- a/internal/format/xm/xm.go
+++ b/internal/format/xm/xm.go
@@ -7,9 +7,7 @@ import (
 	"gotracker/internal/player/intf"
 )
 
-type format struct {
-	intf.Format
-}
+type format struct{}
 
 var (
 	// XM is the exported interface to the XM file loader


### PR DESCRIPTION
## Fixed or Changed
- Clean up format managers
  - spurious use of interfaces as member variables. 🙅 
  - some missing interface definitions in XM and IT format managers.
- Upgrade project to go 1.17